### PR TITLE
Fetch tasks via CORS

### DIFF
--- a/src/api/loader.coffee
+++ b/src/api/loader.coffee
@@ -64,7 +64,7 @@ handleAPIEvent = (apiEventChannel, baseUrl, setting, eventData = {}) ->
 loader = (apiEventChannel, settings) ->
 
   _.each settings.endpoints, (setting, eventName) ->
-    apiEventChannel.on eventName, _.partial(handleAPIEvent, apiEventChannel, settings.baseUrl, setting)
+    apiEventChannel.on eventName, _.partial(handleAPIEvent, apiEventChannel, settings.baseUrl or setting.baseUrl, setting)
 
 
 module.exports = loader

--- a/src/api/loader.coffee
+++ b/src/api/loader.coffee
@@ -18,10 +18,7 @@ getAjaxSettingsByEnv = (isLocal, baseUrl, setting, eventData) ->
     apiSetting.url = "#{interpolate(apiSetting.url, data)}/#{apiSetting.method}.json"
     apiSetting.method = 'GET'
   else
-    CSRF_Token = document.head.querySelector('meta[name=csrf-token]')?.getAttribute("content")
-    apiSetting.headers =
-      'X-CSRF-Token': CSRF_Token
-      token: null
+    apiSetting.withCredentials = true
     apiSetting.url = "#{baseUrl}/#{interpolate(apiSetting.url, data)}"
 
   apiSetting

--- a/src/api/settings.coffee
+++ b/src/api/settings.coffee
@@ -1,6 +1,7 @@
 settings =
-  # # set/comment in to use actual BE
-  # baseUrl: 'http://localhost:3001'
+  # to customize, set environmental var BASE_URL when building or running webpack-dev-server
+  # Currently is set on an endpoint by endpoint basis until all are implemented by BE
+  # baseUrl: process?.env?.BASE_URL
 
   endpoints:
     'exercise.*.send.save':
@@ -26,6 +27,7 @@ settings =
     'task.*.send.fetchByModule':
       url: 'api/cc/tasks/{collectionUUID}/{moduleUUID}'
       method: 'GET'
+      baseUrl: process?.env?.BASE_URL
       completedEvent: 'task.{collectionUUID}/{moduleUUID}.receive.fetchByModule'
 
 module.exports = settings

--- a/webpack-helper/configs.coffee
+++ b/webpack-helper/configs.coffee
@@ -2,7 +2,7 @@ webpack = require 'webpack'
 ExtractTextPlugin = require 'extract-text-webpack-plugin'
 webpackUMDExternal = require 'webpack-umd-external'
 
-DEV_PORT = process.env['PORT'] or 8000
+DEV_PORT = process.env['PORT'] or 9000
 DEV_LOADERS = ['react-hot', 'webpack-module-hot-accept']
 
 # base config, true for all builds no matter what conditions

--- a/webpack-helper/configs.coffee
+++ b/webpack-helper/configs.coffee
@@ -27,8 +27,8 @@ base =
   plugins: [
     # TODO check what plugins are need
     # new webpack.NormalModuleReplacementPlugin(/\/react\/lib\/cloneWithProps/, '../../react-clonewithprops/index.js')
-    # Use the production version of React (no warnings/runtime checks)
-    new webpack.DefinePlugin({ 'process.env': { NODE_ENV: JSON.stringify('production') } })
+    # Use the production version of React (no warnings/runtime checks), and pass the BASE_URL along
+    new webpack.EnvironmentPlugin( 'NODE_ENV', 'BASE_URL' )
     new ExtractTextPlugin('main.css')
     new webpack.optimize.DedupePlugin()
   ]

--- a/webpack-helper/configs.coffee
+++ b/webpack-helper/configs.coffee
@@ -2,7 +2,7 @@ webpack = require 'webpack'
 ExtractTextPlugin = require 'extract-text-webpack-plugin'
 webpackUMDExternal = require 'webpack-umd-external'
 
-DEV_PORT = process.env['PORT'] or 9000
+DEV_PORT = process.env['PORT'] or 8001
 DEV_LOADERS = ['react-hot', 'webpack-module-hot-accept']
 
 # base config, true for all builds no matter what conditions


### PR DESCRIPTION
This: 
- Changes the default port from 8000 to 8001.   This will allow both tutor and concept coach to run concurrently.
- Modifies the `baseUrl` so it can be read from the BASE_URL environmental variable.  The setting's needed so the code knows what server it should interact with
- Updates the endpoints so the baseUrl can be set on individual ones.  We can update them as they become available on the BE
- Sets the `withCredentials` option on remote requests, as well as removes the CRSF token.  We won't have that available since we're operating remotely.

Tested loading with https://github.com/openstax/tutor-server/pull/741
