### PR TITLE
Logout support

### DIFF
--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -55,7 +55,6 @@ ConceptCoach = React.createClass
 
   getUserState: ->
     course = User.getCourse(@props.collectionUUID)
-
     isLoggedIn: User.isLoggedIn(),
     isLoaded: User.isLoaded,
     isRegistered: course?.isRegistered()

--- a/src/user/accounts-iframe-mixin.cjsx
+++ b/src/user/accounts-iframe-mixin.cjsx
@@ -23,6 +23,11 @@ AccountsIframeMixin =
     @setState(isLoading: false)
     @onIframeReady()
 
+  # called when an login process completes
+  onLogin: (payload) ->
+    api.channel.emit 'user.receive.statusUpdate', data: payload
+    @props.onComplete()
+
   displayLoadingStatus: ->
     @state.isLoading and not User.endpoints.is_stubbed
 

--- a/src/user/accounts-iframe-mixin.cjsx
+++ b/src/user/accounts-iframe-mixin.cjsx
@@ -23,11 +23,11 @@ AccountsIframeMixin =
     @setState(isLoading: false)
     @onIframeReady()
 
-  loadPage: (pageName) ->
-    @setState(isLoading: true)
-    @sendCommand('loadPage', pageName)
+  displayLoadingStatus: ->
+    @state.isLoading and not User.endpoints.is_stubbed
 
-  sendCommand: (command, payload) ->
+  sendCommand: (command, payload = {}) ->
+    @setState(isLoading: true)
     msg = JSON.stringify(data: {"#{command}": payload})
     React.findDOMNode(@refs.iframe).contentWindow.postMessage(msg, '*')
 
@@ -51,7 +51,9 @@ AccountsIframeMixin =
   renderIframe: ->
     # the other side of the iframe will validate our address and then only send messages to it
     me = window.location.protocol + '//' + window.location.host
-    url = "#{User.endpoints.accounts_iframe}?parent=#{me}"
+
+    url = if User.isLoggingOut then User.endpoints.iframe_logout else User.endpoints.accounts_iframe
+    url = "#{url}?parent=#{me}"
     <iframe src={url} ref='iframe'
       style={width: @state.width, height: @state.height, border: 0}
       id="OxAccountIframe" name="OxAccountIframe">

--- a/src/user/login.cjsx
+++ b/src/user/login.cjsx
@@ -12,11 +12,6 @@ UserLogin = React.createClass
   propTypes:
     onComplete: React.PropTypes.func.isRequired
 
-  # called when an login process completes
-  onLogin: (payload) ->
-    api.channel.emit 'user.receive.statusUpdate', data: payload
-    @props.onComplete()
-
   # called by iframe when it's content is loaded and it's ready for requests
   onIframeReady: ->
     if User.isLoggingOut

--- a/src/user/login.cjsx
+++ b/src/user/login.cjsx
@@ -1,6 +1,8 @@
 React = require 'react'
 classnames = require 'classnames'
 
+api   = require '../api'
+
 AccountsIframe = require './accounts-iframe-mixin'
 User  = require './model'
 
@@ -17,11 +19,13 @@ UserLogin = React.createClass
 
   # called by iframe when it's content is loaded and it's ready for requests
   onIframeReady: ->
-    @setState(isLoading: true)
-    @sendCommand('displayLogin', User.endpoints.iframe_login)
+    if User.isLoggingOut
+      @sendCommand('displayLogout', User.endpoints.iframe_login)
+    else
+      @sendCommand('displayLogin', User.endpoints.iframe_login)
 
   render: ->
-    classlist = classnames('user-login', 'is-loading': @state.isLoading)
+    classlist = classnames('user-login', 'is-loading': @displayLoadingStatus())
     <div className={classlist}>
       <div className="heading">
         <h3 className="title">{@state?.title}</h3>

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -20,9 +20,11 @@ User =
     _.extend(this, data.user)
     @courses = _.map data.courses, (course) => new Course(@, course)
     @channel.emit('change')
+    delete @isLoggingOut
 
   logout: ->
     _.extend(this, BLANK_USER)
+    @isLoggingOut = true
     @channel.emit('change')
 
   getCourse: (collectionUUID) ->
@@ -43,6 +45,7 @@ User =
 
   onCourseUpdate: (course) ->
     @channel.emit('change')
+
   removeCourse: (course) ->
     index = @courses.indexOf(course)
     @courses.splice(index, 1) unless index is -1
@@ -54,7 +57,12 @@ api.channel.on 'user.receive.*', ({data}) ->
   if data.access_token
     api.channel.emit('set.access_token', data.access_token)
   User.endpoints = data.endpoints
-  if data.user then User.update(data) else User.logout()
+  if data.user
+    User.update(data)
+  else
+    _.extend(this, BLANK_USER)
+    User.channel.emit('change')
+
 
 # start out as a blank user
 _.extend(User, BLANK_USER)

--- a/src/user/profile.cjsx
+++ b/src/user/profile.cjsx
@@ -12,10 +12,10 @@ UserProfile = React.createClass
 
   # called by iframe when it's content is loaded and it's ready for requests
   onIframeReady: ->
-    @loadPage('profile')
+    @sendCommand('displayProfile')
 
   render: ->
-    classlist = classnames('user-profile', 'is-loading': @state.isLoading)
+    classlist = classnames('user-profile', 'is-loading': @displayLoadingStatus() )
 
     <div className={classlist}>
       <div className="heading">


### PR DESCRIPTION
CORS isn't ideal logging out since it doesn't follow redirects.  To fully log out we'd have to logout of both tutor and accounts. Normally that's handled by first logging out of tutor and it redirects to accounts.

This logs out the user inside the iframe, and after logout the iframe displays the login page.  
Goes along with https://github.com/openstax/tutor-server/pull/808  and https://github.com/openstax/accounts/pull/210

Can be merged before them, but logout will not function.
