### PR TITLE
Display spy mode information on tasks

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "interpolate": "^0.1.0",
     "lodash": "^3.10.1",
     "moment": "^2.9.0",
-    "openstax-react-components": "openstax/react-components#7bf99e3",
+    "openstax-react-components": "openstax/react-components#b1d67bc",
     "underscore": "~1.8.2"
   },
   "devDependencies": {

--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 classnames = require 'classnames'
-{SmartOverflow} = require 'openstax-react-components'
+{SmartOverflow, SpyMode} = require 'openstax-react-components'
 
 {Task} = require '../task'
 {Navigation} = require './navigation'
@@ -93,10 +93,12 @@ ConceptCoach = React.createClass
       loading: not (isLoggedIn or isLoaded)
 
     <div className='concept-coach'>
-      <Navigation key='user-status' close={@props.close} course={course}/>
-      <div className={className}>
-        {@childComponent()}
-      </div>
+      <SpyMode.Wrapper>
+        <Navigation key='user-status' close={@props.close} course={course}/>
+        <div className={className}>
+          {@childComponent()}
+        </div>
+      </SpyMode.Wrapper>
     </div>
 
 module.exports = {ConceptCoach, channel}

--- a/src/task/index.cjsx
+++ b/src/task/index.cjsx
@@ -1,5 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
+{SpyMode} = require 'openstax-react-components'
+
 {channel} = tasks = require './collection'
 api = require '../api'
 {Reactive} = require '../reactive'
@@ -64,6 +66,7 @@ TaskBase = React.createClass
     <div className='concept-coach-task'>
       {breadcrumbs}
       {panel}
+      <SpyMode.Content>{JSON.stringify(task.spy)}</SpyMode.Content>
     </div>
 
 


### PR DESCRIPTION
Depends on https://github.com/openstax/react-components/pull/12 and https://github.com/openstax/tutor-server/pull/817

Can be merged before BE pr, just won't display anything until that's complete.

![screen shot 2015-11-17 at 4 17 08 pm](https://cloud.githubusercontent.com/assets/79566/11226609/aef282e4-8d46-11e5-91b8-3d47bec12afd.png)
