### PR TITLE
Remove regex to replace tutor with concept coach

### DIFF
--- a/src/user/accounts-iframe-mixin.cjsx
+++ b/src/user/accounts-iframe-mixin.cjsx
@@ -16,8 +16,7 @@ AccountsIframeMixin =
     @setState(height: height)
 
   setTitle: (title) ->
-    # Hack for expediency.  Replace strings that mention tutor with Concept Coach
-    @setState(title: title.replace(/\btutor\b/gi, "Concept Coach"))
+    @setState(title: title)
 
   iFrameReady: ->
     @setState(isLoading: false)


### PR DESCRIPTION
No longer needed now that BE has been updated to not read "Tutor" in https://github.com/openstax/accounts/pull/212
