### PR TITLE
Display server errors in modal

### DIFF
--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -1,10 +1,12 @@
 React = require 'react'
+
 classnames = require 'classnames'
 {SmartOverflow, SpyMode} = require 'openstax-react-components'
 
 {Task} = require '../task'
 navigation = {Navigation} = require '../navigation'
 CourseRegistration = require '../course/registration'
+ErrorNotification = require './error-notification'
 UserLogin = require '../user/login'
 UserProfile = require '../user/profile'
 
@@ -111,6 +113,8 @@ ConceptCoach = React.createClass
       loading: not (isLoggedIn or isLoaded)
 
     <div className='concept-coach'>
+      <ErrorNotification />
+
       <SpyMode.Wrapper>
         <Navigation key='user-status' close={@props.close} course={course}/>
         <div className={className}>

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -7,7 +7,7 @@ api = require '../api'
 ErrorNotification = React.createClass
 
   getInitialState: ->
-    error: false
+    error: false, isShowingDetails: false
 
   componentWillMount: ->
     api.channel.on 'error', @onError
@@ -26,17 +26,35 @@ ErrorNotification = React.createClass
         )
     @setState(errors: errors)
 
+  toggleDetails: ->
+    @setState(isShowingDetails: not @state.isShowingDetails)
+
   onHide: ->
     @setState(errors: false)
+
+  renderDetails: ->
+    <BS.Panel header="Error Details">
+      <ul className="errors-listing">
+        {for error, i in @state.errors
+          <li key={i}>{error}</li>}
+      </ul>
+    </BS.Panel>
 
   render: ->
     return null unless @state.errors
     <BS.Modal className='errors' onRequestHide={@onHide} title="Server Error">
       <div className='modal-body'>
-        <ul>
-          {for error in @state.errors
-            <li>{error}</li>}
-        </ul>
+        <h3>Server error encountered</h3>
+        <p>
+          An unexpected error has occured.  Please
+          visit <a target="zendesk"
+            href="https://openstaxtutor.zendesk.com/hc/en-us/requests/new"
+          > our support site </a> so we can help to diagnose and correct the issue.
+        </p>
+        <BS.Button onClick={@toggleDetails}>
+          {if @state.isShowingDetails then "Hide" else "Show"} Details
+        </BS.Button>
+        {@renderDetails() if @state.isShowingDetails}
       </div>
       <div className='modal-footer'>
         <BS.Button className='ok' bsStyle='primary' onClick={@onHide}>OK</BS.Button>

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -1,0 +1,47 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+
+api = require '../api'
+
+
+ErrorNotification = React.createClass
+
+  getInitialState: ->
+    error: false
+
+  componentWillMount: ->
+    api.channel.on 'error', @onError
+
+  componentWillUnmount: ->
+    api.channel.off 'error', @onError
+
+  onError: ({response}) ->
+    return if response.stopErrorDisplay # someone else is handling displaying the error
+    errors = ["#{response.status}: #{response.statusText}"]
+    if response.data?.errors # we have something from server to display
+      errors = errors.concat(
+        _.flatten _.map response.data.errors, (error) ->
+          # All 422 errors from BE *should* have a "code" property.  If not, show whatever it is
+          if error.code then error.code else JSON.stringify(error)
+        )
+    @setState(errors: errors)
+
+  onHide: ->
+    @setState(errors: false)
+
+  render: ->
+    return null unless @state.errors
+    <BS.Modal className='errors' onRequestHide={@onHide} title="Server Error">
+      <div className='modal-body'>
+        <ul>
+          {for error in @state.errors
+            <li>{error}</li>}
+        </ul>
+      </div>
+      <div className='modal-footer'>
+        <BS.Button className='ok' bsStyle='primary' onClick={@onHide}>OK</BS.Button>
+      </div>
+    </BS.Modal>
+
+
+module.exports = ErrorNotification

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -47,7 +47,7 @@ ErrorNotification = React.createClass
         <h3>Server error encountered</h3>
         <p>
           An unexpected error has occured.  Please
-          visit <a target="zendesk"
+          visit <a target="_blank"
             href="https://openstaxtutor.zendesk.com/hc/en-us/requests/new"
           > our support site </a> so we can help to diagnose and correct the issue.
         </p>

--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -84,11 +84,12 @@ class Course
       data: { id: @id, student_identifier: studentId}
     )
 
-  _onConfirmed:  ({data}) ->
-    if data.to
+  _onConfirmed:  (response) ->
+    if response.data?.to
       _.extend(@, data.to.course)
       @periods = [ data.to.period ]
-    @errors = data.errors
+    @errors = response.data.errors
+    response.stopErrorDisplay = true if @errors
     delete @status unless @hasErrors() # blank status indicates good to go
     @channel.emit('change')
 
@@ -101,10 +102,11 @@ class Course
       book_uuid: @ecosystem_book_uuid, enrollment_code: inviteCode
     })
 
-  _onRegistered: ({data}) ->
+  _onRegistered: (response) ->
     # confirmation has completed
-    _.extend(@, data)
-    @errors = data.errors
+    _.extend(@, response.data)
+    @errors = response.data.errors
+    response.stopErrorDisplay = true if @errors
     @channel.emit('change')
 
 


### PR DESCRIPTION
Also add zendesk support link.  The link currently points to the same site tutor uses. ( https://openstaxtutor.zendesk.com/hc/en-us/requests/new )

![screen shot 2015-11-30 at 3 47 46 pm](https://cloud.githubusercontent.com/assets/79566/11485607/c9c51ba8-9779-11e5-90e3-2277543616f4.png)
![screen shot 2015-11-30 at 3 47 33 pm](https://cloud.githubusercontent.com/assets/79566/11485608/ca1ca616-9779-11e5-85b0-b30e4de8a9c7.png)
