### PR TITLE
Discard non-concept coach courses from listing

### DIFF
--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -106,6 +106,8 @@ class Course
     # confirmation has completed
     _.extend(@, response.data)
     @errors = response.data.errors
+    # a freshly registered course doesn't contain the is_concept_coach flag
+    @is_concept_coach = true
     response.stopErrorDisplay = true if @errors
     @channel.emit('change')
 

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -18,7 +18,8 @@ User =
 
   update: (data) ->
     _.extend(this, data.user)
-    @courses = _.map data.courses, (course) -> new Course(course)
+    @courses = _.compact _.map data.courses, (course) -> new Course(course) if course.is_concept_coach
+
     @channel.emit('change')
     delete @isLoggingOut
 


### PR DESCRIPTION
Since the widget doesn't need to know anything about non-concept coach courses I'm just filtering them out on load.  This way they don't show up on the chooser or pollute other areas of the codebase.
