### PR TITLE
Don't display loading indicator on login & profile

### DIFF
--- a/src/user/accounts-iframe-mixin.cjsx
+++ b/src/user/accounts-iframe-mixin.cjsx
@@ -6,10 +6,10 @@ User  = require './model'
 AccountsIframeMixin =
 
   getInitialState: ->
-    width: '100%', height: 400, isLoading: true
+    width: '100%', height: 400
 
   pageLoad: (page) ->
-    @setState(isLoading: false)
+
 
   # Note: we're currently not doing anything with the width because we want that to stay at 100%
   pageResize: ({width, height}) ->
@@ -19,7 +19,6 @@ AccountsIframeMixin =
     @setState(title: title)
 
   iFrameReady: ->
-    @setState(isLoading: false)
     @onIframeReady()
 
   # called when an login process completes
@@ -27,11 +26,7 @@ AccountsIframeMixin =
     api.channel.emit 'user.status.receive.fetch', data: payload
     @props.onComplete()
 
-  displayLoadingStatus: ->
-    @state.isLoading and not User.endpoints.is_stubbed
-
   sendCommand: (command, payload = {}) ->
-    @setState(isLoading: true)
     msg = JSON.stringify(data: {"#{command}": payload})
     React.findDOMNode(@refs.iframe).contentWindow.postMessage(msg, '*')
 

--- a/src/user/login.cjsx
+++ b/src/user/login.cjsx
@@ -20,8 +20,7 @@ UserLogin = React.createClass
       @sendCommand('displayLogin', User.endpoints.iframe_login)
 
   render: ->
-    classlist = classnames('user-login', 'is-loading': @displayLoadingStatus())
-    <div className={classlist}>
+    <div className='user-login'>
       <div className="heading">
         <h3 className="title">{@state?.title}</h3>
       </div>

--- a/src/user/profile.cjsx
+++ b/src/user/profile.cjsx
@@ -15,9 +15,7 @@ UserProfile = React.createClass
     @sendCommand('displayProfile')
 
   render: ->
-    classlist = classnames('user-profile', 'is-loading': @displayLoadingStatus() )
-
-    <div className={classlist}>
+    <div className='user-profile'>
       <div className="heading">
         <h3 className="title">{@state?.title}</h3>
         <i className='close-icon' onClick={@props.onComplete}/>


### PR DESCRIPTION
When the iframe is opened in order to display terms the pageLoaded
signal isn't fired so the "Loading" mask always displays.

Will be needed when https://github.com/openstax/tutor-server/pull/844 is completed
