### PR TITLE
Don't display error dialog when the error is handled elsewhere

### DIFF
--- a/src/api/loader.coffee
+++ b/src/api/loader.coffee
@@ -63,7 +63,7 @@ handleAPIEvent = (apiEventChannel, baseUrl, setting, eventData = {}) ->
 
           apiEventChannel.emit(failedEvent, failedData)
         setting.onFail?(response) or defaultFail(response)
-        apiEventChannel.emit('error', response: response, apiSetting: apiSetting)
+        apiEventChannel.emit('error', {response, apiSetting, failedData})
       )
   , delay
 

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -15,8 +15,8 @@ ErrorNotification = React.createClass
   componentWillUnmount: ->
     api.channel.off 'error', @onError
 
-  onError: ({response}) ->
-    return if response.stopErrorDisplay # someone else is handling displaying the error
+  onError: ({response, failedData}) ->
+    return if failedData.stopErrorDisplay # someone else is handling displaying the error
     errors = ["#{response.status}: #{response.statusText}"]
     if response.data?.errors # we have something from server to display
       errors = errors.concat(


### PR DESCRIPTION
Maybe fixes #41 - not sure if that's the same or not.  It does fix a bug where the error dialog is displayed if a course invite code is incorrect
