### PR TITLE
selectively silence errors from task api endpoint

### DIFF
--- a/src/api/loader.coffee
+++ b/src/api/loader.coffee
@@ -57,11 +57,13 @@ handleAPIEvent = (apiEventChannel, baseUrl, setting, eventData = {}) ->
         apiEventChannel.emit(completedEvent, completedData)
 
       ).catch((response) ->
+
+        failedData = getResponseDataByEnv(isLocal, eventData, response)
+
         if _.isString(setting.failedEvent)
           failedEvent = interpolate(setting.failedEvent, eventData.data)
-          failedData = getResponseDataByEnv(isLocal, eventData, response)
-
           apiEventChannel.emit(failedEvent, failedData)
+
         setting.onFail?(response) or defaultFail(response)
         apiEventChannel.emit('error', {response, apiSetting, failedData})
       )

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -18,9 +18,9 @@ ErrorNotification = React.createClass
   onError: ({response, failedData}) ->
     return if failedData.stopErrorDisplay # someone else is handling displaying the error
     errors = ["#{response.status}: #{response.statusText}"]
-    if response.data?.errors # we have something from server to display
+    if failedData.data?.errors # we have something from server to display
       errors = errors.concat(
-        _.flatten _.map response.data.errors, (error) ->
+        _.flatten _.map failedData.data.errors, (error) ->
           # All 422 errors from BE *should* have a "code" property.  If not, show whatever it is
           if error.code then error.code else JSON.stringify(error)
         )

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -31,6 +31,7 @@ load = (taskId, data) ->
   channel.emit("load.#{taskId}", {data, status})
 
 update = (eventData) ->
+  return unless eventData?
   {data, query} = eventData
   load(query, data)
 


### PR DESCRIPTION
'page_has_no_exercises' in particular, fixes #40 and updates #42
### 'page_has_no_exercises' silenced

![screen shot 2015-12-02 at 11 58 12 pm](https://cloud.githubusercontent.com/assets/2483873/11553177/cb05ca60-9951-11e5-94a8-0d28cd95cdb4.png)
### fake other error shows

![screen shot 2015-12-03 at 12 03 22 am](https://cloud.githubusercontent.com/assets/2483873/11553178/cb072f36-9951-11e5-87e1-a799fb46cea5.png)
