### PR TITLE
Null check for failedData and only iterate arrays

### DIFF
--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -16,9 +16,9 @@ ErrorNotification = React.createClass
     api.channel.off 'error', @onError
 
   onError: ({response, failedData}) ->
-    return if failedData.stopErrorDisplay # someone else is handling displaying the error
+    return if failedData?.stopErrorDisplay # someone else is handling displaying the error
     errors = ["#{response.status}: #{response.statusText}"]
-    if failedData.data?.errors # we have something from server to display
+    if _.isArray(failedData.data?.errors) # we have something from server to display
       errors = errors.concat(
         _.flatten _.map failedData.data.errors, (error) ->
           # All 422 errors from BE *should* have a "code" property.  If not, show whatever it is


### PR DESCRIPTION
I noticed that we're also receiving JS errors whenever the server throws a 500 
