### PR TITLE
Fix error when confirming course registration

### DIFF
--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -85,10 +85,11 @@ class Course
     )
 
   _onConfirmed:  (response) ->
-    if response.data?.to
+    {data} = response
+    if data?.to
       _.extend(@, data.to.course)
       @periods = [ data.to.period ]
-    @errors = response.data.errors
+    @errors = data?.errors
     response.stopErrorDisplay = true if @errors
     delete @status unless @hasErrors() # blank status indicates good to go
     @channel.emit('change')


### PR DESCRIPTION
AKA, the promise ate my exception.

When a network callback completes, the emit occurs inside a promise callback.  This means that any JS exceptions will be caught and the promise rejected, without any nice error messages.  Additionally the error dialog will be displayed since the rejection is also how server errors are handled.

In this case the bug was that data was undefined.  It took me putting a breakpoint in the error display modal to spot the error though :(
