### PR TITLE
Check for null response in registration/confirmation handlers

### DIFF
--- a/src/api/loader.coffee
+++ b/src/api/loader.coffee
@@ -58,10 +58,12 @@ handleAPIEvent = (apiEventChannel, baseUrl, setting, requestEvent = {}) ->
     $.ajax(apiSetting)
       .then((responseData) ->
         delete LOADING[apiSetting.url]
-        completedEvent = interpolate(setting.completedEvent, requestEvent.data)
-        completedData = getResponseDataByEnv(isLocal, requestEvent, responseData)
-        apiEventChannel.emit(completedEvent, completedData)
-
+        try
+          completedEvent = interpolate(setting.completedEvent, requestEvent.data)
+          completedData = getResponseDataByEnv(isLocal, requestEvent, responseData)
+          apiEventChannel.emit(completedEvent, completedData)
+        catch error
+          apiEventChannel.emit('error', {apiSetting, response: responseData, failedData: completedData, exception: error})
       ).fail((response) ->
         delete LOADING[apiSetting.url]
 

--- a/src/concept-coach/error-notification.cjsx
+++ b/src/concept-coach/error-notification.cjsx
@@ -15,9 +15,11 @@ ErrorNotification = React.createClass
   componentWillUnmount: ->
     api.channel.off 'error', @onError
 
-  onError: ({response, failedData}) ->
+  onError: ({response, failedData, exception}) ->
     return if failedData?.stopErrorDisplay # someone else is handling displaying the error
-    if response.status is 0 # either no response, or the response lacked CORS headers and the browser rejected it
+    if exception?
+      errors = [exception.toString()]
+    else if response.status is 0 # either no response, or the response lacked CORS headers and the browser rejected it
       errors = ["Unknown response received from server"]
     else
       errors = ["#{response.status}: #{response.statusText}"]

--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -87,6 +87,7 @@ class Course
     @channel.emit('change')
 
   _onConfirmed:  (response) ->
+    throw new Error("response is empty in onConfirmed") if _.isEmpty(response)
     {data} = response
     if data?.to
       _.extend(@, data.to.course)
@@ -107,9 +108,10 @@ class Course
     @channel.emit('change')
 
   _onRegistered: (response) ->
+    throw new Error("response is empty in onRegistered") if _.isEmpty(response)
     {data} = response
-    _.extend(@, data)
-    @errors = data.errors
+    _.extend(@, data) if data
+    @errors = data?.errors
     # a freshly registered course doesn't contain the is_concept_coach flag
     @is_concept_coach = true
     response.stopErrorDisplay = true if @errors


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/79566/11721002/554047de-9f27-11e5-9346-99915347f2c2.png)
