### PR TITLE
Stop underlineing menu options

### DIFF
--- a/resources/styles/components/navigation/index.less
+++ b/resources/styles/components/navigation/index.less
@@ -17,4 +17,7 @@
       margin-bottom: -(@padding-base-vertical + 1);
     }
   }
+  .navbar .dropdown-menu {
+    text-decoration: none;
+  }
 }


### PR DESCRIPTION
CNX has a rule:
.media-body > #content a:not([role="button"]) {
text-decoration: underline; }

![image](https://cloud.githubusercontent.com/assets/79566/11725102/84a0781c-9f3d-11e5-90eb-8182d22874bf.png)
