### PR TITLE
Only initialize loader api a single time

### DIFF
--- a/src/api/index.coffee
+++ b/src/api/index.coffee
@@ -5,8 +5,14 @@ settings = require './settings'
 
 channel = new EventEmitter2 wildcard: true
 
+# HACK - WORKAROUND
+# MediaBodyView.prototype.initializeConceptCoach calls this multiple times
+# (triggered by back-button and most perhaps search)
+IS_INITIALIZED = false
+
 initialize = (baseUrl) ->
   settings.baseUrl ?= baseUrl
-  loader(channel, settings)
+  loader(channel, settings) unless IS_INITIALIZED
+  IS_INITIALIZED = true
 
 module.exports = {loader, settings, initialize, channel}


### PR DESCRIPTION
CNX sometimes calls `initialize` multiple times.  If we re-init the loader then event listeners on the api channel will be called multiple times.  

You can replicate by putting a breakpoint in the compiled source on cnx and observe it being called on page load and when the bak button is pressed.

Believe this is the root cause of the "already joined course, double submit" bug.

note to @edwoodward and @RoyEJohnson - we'd like to figure out a better solution for this in the future.
