### PR TITLE
CC unloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "bootstrap": "~3.3.2",
     "classnames": "^2.1.3",
+    "dateformat": "^1.0.12",
     "eventemitter2": "^0.4.14",
     "font-awesome": "^4.4.0",
     "interpolate": "^0.1.0",

--- a/src/api/index.coffee
+++ b/src/api/index.coffee
@@ -15,4 +15,8 @@ initialize = (baseUrl) ->
   loader(channel, settings) unless IS_INITIALIZED
   IS_INITIALIZED = true
 
-module.exports = {loader, settings, initialize, channel}
+destroy = ->
+  channel.removeAllListeners()
+  IS_INITIALIZED = false
+
+module.exports = {loader, settings, initialize, destroy, channel}

--- a/src/concept-coach/index.cjsx
+++ b/src/concept-coach/index.cjsx
@@ -65,6 +65,11 @@ stopModelChannels = (models) ->
   _.each models, (model) ->
     model.destroy?() or model.channel?.removeAllListeners?()
 
+deleteProperties = (obj) ->
+  for property, value of obj
+    delete obj[property] unless _.isFunction(obj[property]) or property is 'channel'
+    null
+
 modalCoachWrapped = helpers.wrapComponent(ModalCoach)
 
 class ConceptCoachAPI extends EventEmitter2
@@ -76,7 +81,7 @@ class ConceptCoachAPI extends EventEmitter2
     restAPI.init = _.partial restAPI.initialize, baseUrl
     navigation.init = _.partial navigation.initialize, navOptions
 
-    @models = [restAPI, navigation, User, exercise, progress, task]
+    @models = [restAPI, navigation, User, exercise, progress, task, componentModel]
     initializeModels(@models)
 
     listenAndBroadcast(@)
@@ -86,6 +91,8 @@ class ConceptCoachAPI extends EventEmitter2
   destroy: ->
     @close?()
     stopModelChannels(@models)
+    deleteProperties(@models)
+    deleteProperties(componentModel)
 
     @removeAllListeners()
 

--- a/src/concept-coach/index.cjsx
+++ b/src/concept-coach/index.cjsx
@@ -10,6 +10,8 @@ componentModel = require './model'
 navigation = require '../navigation/model'
 User = require '../user/model'
 exercise = require '../exercise/collection'
+progress = require '../progress/collection'
+task = require '../task/collection'
 
 PROPS = ['moduleUUID', 'collectionUUID', 'cnxUrl']
 
@@ -54,6 +56,9 @@ setupAPIListeners = (componentAPI) ->
   componentAPI.on 'show.*', (eventData) ->
     componentAPI.updateToView(eventData.view)
 
+initializeModels = (models) ->
+  _.each models, (model) ->
+    model.init?()
 
 modalCoachWrapped = helpers.wrapComponent(ModalCoach)
 
@@ -66,9 +71,20 @@ class ConceptCoachAPI extends EventEmitter2
     restAPI.initialize(baseUrl)
     navigation.initialize(navOptions)
 
+    initializeModels [User, exercise, progress, task]
+
     listenAndBroadcast(@)
     setupAPIListeners(@)
-    User.ensureStatusLoaded()
+    User.ensureStatusLoaded(true)
+
+  destroy: ->
+    @close?()
+    restAPI.destroy()
+
+    componentModel.channel.removeAllListeners()
+    navigation.channel.removeAllListeners()
+
+    @removeAllListeners()
 
   setOptions: (options) ->
     isSame = _.isEqual(_.pick(options, PROPS), _.pick(componentModel, PROPS))

--- a/src/exercise/collection.coffee
+++ b/src/exercise/collection.coffee
@@ -34,6 +34,7 @@ getCurrentPanel = (stepId) ->
 get = (stepId) ->
   steps[stepId]
 
-api.channel.on("exercise.*.receive.*", update)
+init = ->
+  api.channel.on("exercise.*.receive.*", update)
 
-module.exports = {fetch, getCurrentPanel, get, channel, quickLoad}
+module.exports = {fetch, getCurrentPanel, get, init, channel, quickLoad}

--- a/src/exercise/index.cjsx
+++ b/src/exercise/index.cjsx
@@ -57,11 +57,9 @@ ExerciseBase = React.createClass
         api.channel.emit("exercise.#{step.id}.send.complete", eventData)
 
       onStepCompleted: ->
-        console.info('onStepCompleted')
         channel.emit("completed.#{step.id}")
 
       onNextStep: ->
-        console.info('onNextStep')
         channel.emit("leave.#{step.id}")
 
     if taskId?

--- a/src/progress/collection.coffee
+++ b/src/progress/collection.coffee
@@ -23,6 +23,7 @@ fetch = (id) ->
 get = (id) ->
   local[id]
 
-api.channel.on("#{apiChannelName}.*.receive.*", update)
+init = ->
+  api.channel.on("#{apiChannelName}.*.receive.*", update)
 
-module.exports = {fetch, get, channel}
+module.exports = {fetch, get, init, channel}

--- a/src/progress/page.cjsx
+++ b/src/progress/page.cjsx
@@ -1,6 +1,6 @@
 React = require 'react'
 _ = require 'underscore'
-moment = require 'moment'
+dateFormat = require 'dateformat'
 classnames = require 'classnames'
 EventEmitter2 = require 'eventemitter2'
 
@@ -11,7 +11,7 @@ PageProgress = React.createClass
   displayName: 'PageProgress'
   getDefaultProps: ->
     page: {}
-    dateFormat: 'MMM. D'
+    dateFormatString: 'mmm. d'
     progressWidth: 30
     progressMargin: 5
     dateBuffer: 100
@@ -23,7 +23,7 @@ PageProgress = React.createClass
   switchModule: (data) ->
     @context.navigator.emit('switch.module', {data, view: 'task'})
   render: ->
-    {page, dateFormat, dateBuffer, maxLength, progressWidth, progressMargin, className} = @props
+    {page, dateFormatString, dateBuffer, maxLength, progressWidth, progressMargin, className} = @props
     {componentEl} = @state
 
     exercisesProgressWidth = maxLength * progressWidth + (maxLength - 1) * progressMargin
@@ -31,7 +31,7 @@ PageProgress = React.createClass
 
     classes = classnames 'concept-coach-progress-page', className
     section = @sectionFormat(page.chapter_section)
-    pageLastWorked = moment(page.last_worked_at).format(dateFormat)
+    pageLastWorked = dateFormat(new Date(page.last_worked_at), dateFormatString)
 
     sectionProps =
       className: 'chapter-section-prefix'

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -81,10 +81,12 @@ getModuleInfo = (taskId, cnxUrl = '') ->
 
   moduleInfo
 
-api.channel.on("task.*.receive.*", update)
-api.channel.on('task.*.receive.failure', checkFailure)
+init = ->
+  api.channel.on("task.*.receive.*", update)
+  api.channel.on('task.*.receive.failure', checkFailure)
 
 module.exports = {
+  init,
   load,
   fetch,
   fetchByModule,

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -73,6 +73,14 @@ User =
         _.extend(this, BLANK_USER)
         User.channel.emit('change')
 
+  destroy: ->
+    User.channel.removeAllListeners()
+
+    _.each @courses, (course) ->
+      course.channel.removeAllListeners()
+
+    delete @courses
+
 
 # start out as a blank user
 _.extend(User, BLANK_USER)

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -60,17 +60,18 @@ User =
     @isLoggingOut = false
     @channel.emit('logout.received')
 
-api.channel.on 'user.status.receive.*', ({data}) ->
-  User.isLoaded = true
+  init: ->
+    api.channel.on 'user.status.receive.*', ({data}) ->
+      User.isLoaded = true
 
-  if data.access_token
-    api.channel.emit('set.access_token', data.access_token)
-  User.endpoints = data.endpoints
-  if data.user
-    User.update(data)
-  else
-    _.extend(this, BLANK_USER)
-    User.channel.emit('change')
+      if data.access_token
+        api.channel.emit('set.access_token', data.access_token)
+      User.endpoints = data.endpoints
+      if data.user
+        User.update(data)
+      else
+        _.extend(this, BLANK_USER)
+        User.channel.emit('change')
 
 
 # start out as a blank user


### PR DESCRIPTION
On webview, back "closes" the parent view, and then reinitialize the view, causing CC to be reinitialized without removing loaded event listeners.  This PR focuses primarily on the CC component `destroy` function that will be called on the parent view close to cleanly remove events, and the CC widget itself.

This should fix various multiple event firings across the CC widget more extensively than just preventing api re-initialization.

Also, takes out `moment.js`, decreasing build by almost 200 KB

Matches Connexions/webview#1313
