### PR TITLE
Reset stores when user changes

### DIFF
--- a/src/exercise/collection.coffee
+++ b/src/exercise/collection.coffee
@@ -1,7 +1,11 @@
 EventEmitter2 = require 'eventemitter2'
 api = require '../api'
-
 steps = {}
+
+user = require '../user/model'
+user.channel.on 'change', ->
+  steps = {}
+
 channel = new EventEmitter2 wildcard: true
 
 quickLoad = (stepId, data) ->

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -5,6 +5,11 @@ api = require '../api'
 exercises = require '../exercise/collection'
 
 tasks = {}
+
+user = require '../user/model'
+user.channel.on 'change', ->
+  tasks = {}
+
 channel = new EventEmitter2 wildcard: true
 
 ERRORS_TO_SILENCE = ['page_has_no_exercises']


### PR DESCRIPTION
Fixes bugs that occur when a user logs out and then a different user (who's also registered for the same course) logs in.  When that happens, CC attempts to fetch steps from the old task.   

We don't really need to clear the exercise collection to prevent the bug, but it's  a good idea regardless.
