### PR TITLE
Update react shared components for mathjax fixes

### DIFF
--- a/demo-mathjax-config.coffee
+++ b/demo-mathjax-config.coffee
@@ -1,0 +1,81 @@
+$ = require 'jquery'
+
+# ripped from webview
+MATHJAX_CONFIG =
+  jax: [
+    'input/MathML',
+    'input/TeX',
+    'input/AsciiMath',
+    'output/NativeMML',
+    'output/HTML-CSS'
+  ],
+  extensions: [
+    'asciimath2jax.js',
+    'tex2jax.js',
+    'mml2jax.js',
+    'MathMenu.js',
+    'MathZoom.js'
+  ],
+  tex2jax: {
+    inlineMath: [
+      ['[TEX_START]', '[TEX_END]'],
+      ['\\(', '\\)']
+    ]
+  },
+  TeX: {
+    extensions: [
+      'AMSmath.js',
+      'AMSsymbols.js',
+      'noErrors.js',
+      'noUndefined.js'
+    ],
+    noErrors: {
+      disabled: true
+    }
+  },
+  AsciiMath: {
+    noErrors: {
+      disabled: true
+    }
+  }
+
+typesetMath = (node) ->
+  # straight up copy of webview's mathjax fn
+  $mathElements = $(node).find('[data-math]:not(.math-rendered)')
+  console.log $mathElements
+  $mathElements.each (iter, element) ->
+
+    $element = $(element)
+    formula = $element.data('math')
+
+    mathTex = "[TEX_START]#{formula}[TEX_END]"
+    $element.text(mathTex)
+
+    # Moved adding to MathJax queue here. Means the queue gets pushed onto more (once per math element),
+    # but what it trys to parse for matching math is WAY less than the whole page.
+    MathJax.Hub.Queue(['Typeset', MathJax.Hub], $element[0])
+    MathJax.Hub.Queue( ->
+      $element[0].classList.add('math-rendered')
+    )
+
+
+startMathJax = ->
+
+  configuredCallback = ->
+    window.MathJax.Hub.Configured()
+
+  if window.MathJax?.Hub
+    window.MathJax.Hub.Config(MATHJAX_CONFIG)
+    # Does not seem to work when passed to Config
+    window.MathJax.Hub.processSectionDelay = 0
+    configuredCallback()
+  else
+    # If the MathJax.js file has not loaded yet:
+    # Call MathJax.Configured once MathJax loads and
+    # loads this config JSON since the CDN URL
+    # says to `delayStartupUntil=configured`
+    MATHJAX_CONFIG.AuthorInit = configuredCallback
+
+    window.MathJax = MATHJAX_CONFIG
+
+module.exports = {typesetMath, startMathJax}

--- a/demo.cjsx
+++ b/demo.cjsx
@@ -2,6 +2,7 @@ ConceptCoachAPI = require './src/concept-coach'
 
 api = require './src/api'
 AUTOSHOW = false
+{startMathJax, typesetMath} = require './demo-mathjax-config'
 
 SETTINGS =
   STUBS:
@@ -26,6 +27,8 @@ loadApp = ->
   unless document.readyState is 'interactive'
     return false
 
+  startMathJax()
+
   mainDiv = document.getElementById('react-root-container')
   buttonA = document.getElementById('launcher')
   buttonB = document.getElementById('launcher-other-course')
@@ -36,8 +39,7 @@ loadApp = ->
     collectionUUID: settings.COLLECTION_UUID
     moduleUUID: settings.MODULE_UUID
     cnxUrl: settings.CNX_URL
-    processHtmlAndMath: ->
-      console.info('HELLO')
+    processHtmlAndMath: typesetMath # from demo
 
   initialModel = _.clone(demoSettings)
   initialModel.mounter = mainDiv

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "keymaster": "^1.6.2",
     "lodash": "^3.10.1",
     "moment": "^2.9.0",
-    "openstax-react-components": "openstax/react-components#e4e5b8cc82ecbf0debf31d133c5d87a655805ebc",
+    "openstax-react-components": "openstax/react-components#0064fc20f6b7d07ae9649bb79956b0603081a7b0",
     "underscore": "~1.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Updates react components to include https://github.com/openstax/react-components/pull/28

Danger!  This is somewhat untested.  My web view isn't configured currently, to workaround that I updated the demo to configure mathjax to match web view.   

There's a weird artifact that's being rendered as you can see in the screenshoton chrome.  I think this is a known bug on Chrome and Mathjax's part  Read MathJax issue 1300 for more details.  

![image](https://cloud.githubusercontent.com/assets/79566/11921073/f182e46e-a745-11e5-8afd-084e5bd27dfd.png)
