### PR TITLE
ensure multiple mounts does not happen to prevent memory leaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "keymaster": "^1.6.2",
     "lodash": "^3.10.1",
     "moment": "^2.9.0",
-    "openstax-react-components": "openstax/react-components#0064fc20f6b7d07ae9649bb79956b0603081a7b0",
+    "openstax-react-components": "openstax/react-components#c4030e6e40eb63e2800bfb7c949129fdf4232ee0",
     "underscore": "~1.8.2"
   },
   "devDependencies": {

--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -52,13 +52,15 @@ ConceptCoach = React.createClass
     bookUrlPattern: React.PropTypes.string
     close: React.PropTypes.func
     navigator: React.PropTypes.instanceOf(EventEmitter2)
+    processHtmlAndMath: React.PropTypes.func
 
   getChildContext: ->
     {view} = @state
     {cnxUrl, close, moduleUUID, collectionUUID} = @props
     bookUrlPattern = '{cnxUrl}/contents/{ecosystem_book_uuid}'
+    processHtmlAndMath = @props.processHtmlAndMath
 
-    {view, cnxUrl, close, bookUrlPattern, navigator,  moduleUUID, collectionUUID}
+    {view, cnxUrl, close, processHtmlAndMath, bookUrlPattern, navigator,  moduleUUID, collectionUUID}
 
   componentWillMount: ->
     User.ensureStatusLoaded()

--- a/src/concept-coach/coach.cjsx
+++ b/src/concept-coach/coach.cjsx
@@ -10,25 +10,20 @@ Coach = React.createClass
   getDefaultProps: ->
     open: false
     displayLauncher: true
-
-  getInitialState: ->
-    {open} = @props
-    isOpen: open
-
-  componentWillReceiveProps: (nextProps) ->
-    {open} = nextProps
-    @setState(isOpen: open) if open isnt @state.isOpen
+  propTypes:
+    open: React.PropTypes.bool
+    displayLauncher: React.PropTypes.bool
 
   render: ->
-    {isOpen} = @state
+    {open} = @props
     {displayLauncher} = @props
     coachProps = _.omit(@props, 'open')
 
     modal = <CCModal>
       <ConceptCoach {...coachProps}/>
-    </CCModal> if isOpen
+    </CCModal> if open
 
-    launcher = <Launcher/> if displayLauncher
+    launcher = <Launcher isLaunching={open}/> if displayLauncher
 
     <div className='concept-coach-wrapper'>
       {launcher}

--- a/src/concept-coach/index.cjsx
+++ b/src/concept-coach/index.cjsx
@@ -92,7 +92,7 @@ class ConceptCoachAPI extends EventEmitter2
 
   destroy: ->
     @close?()
-    coachWrapped.unmountFrom(componentModel.mounter) if @component?.isMounted()
+    @remove()
 
     stopModelChannels(@models)
     deleteProperties(@models)
@@ -100,12 +100,16 @@ class ConceptCoachAPI extends EventEmitter2
 
     @removeAllListeners()
 
+  remove: ->
+    coachWrapped.unmountFrom(componentModel.mounter) if @component?.isMounted()
+
   setOptions: (options) ->
     isSame = _.isEqual(_.pick(options, PROPS), _.pick(componentModel, PROPS))
     options = _.extend({}, options, isSame: isSame)
     componentModel.update(options)
 
   initialize: (mountNode, props = {}) ->
+    @remove()
     props = _.clone(props)
     props.defaultView ?= if componentModel.isSame then componentModel.view else 'task'
 

--- a/src/concept-coach/launcher/index.cjsx
+++ b/src/concept-coach/launcher/index.cjsx
@@ -10,31 +10,28 @@ classnames = require 'classnames'
 
 Launcher = React.createClass
   displayName: 'Launcher'
-  getInitialState: ->
+  propTypes:
+    isLaunching: React.PropTypes.bool
+    defaultHeight: React.PropTypes.number
+  getDefaultProps: ->
     isLaunching: false
+    defaultHeight: 388
+  getInitialState: ->
+    height: @getHeight()
+  componentWillReceiveProps: (nextProps) ->
+    @setState(height: @getHeight(nextProps)) if @props.isLaunching isnt nextProps.isLaunching
+
+  getHeight: (props) ->
+    props ?= @props
+    {isLaunching, defaultHeight} = props
+    if isLaunching then window.innerHeight else defaultHeight
 
   launch: ->
-    {isLaunching} = @state
-    return if isLaunching
-    @setState(isLaunching: true)
     channel.emit('launcher.clicked')
 
-  close: ->
-    @setState(isLaunching: false)
-
-  shouldComponentUpdate: (nextProps, nextState) ->
-    @state.isLaunching isnt nextState.isLaunching
-
-  componentWillMount: ->
-    channel.on 'coach.unmount.success', @close
-
-  componentWillUnmount: ->
-    channel.off 'coach.unmount.success', @close
-
   render: ->
-    {isLaunching} = @state
-    height = '388px'
-    height = "#{window.innerHeight}px" if isLaunching
+    {isLaunching, defaultHeight} = @props
+    {height} = @state
 
     classes = classnames 'concept-coach-launcher',
       launching: isLaunching
@@ -42,7 +39,7 @@ Launcher = React.createClass
     <div className='concept-coach-launcher-wrapper'>
       <div className={classes} onClick={@launch}>
         <BackgroundAndDesk height={height}/>
-        <LaptopAndMug/>
+        <LaptopAndMug height={defaultHeight}/>
 
         <BS.Button bsStyle='primary' bsSize='large'>Launch Concept Coach</BS.Button>
 

--- a/src/concept-coach/launcher/items.cjsx
+++ b/src/concept-coach/launcher/items.cjsx
@@ -3,11 +3,11 @@ React = require 'react'
 
 LaptopAndMug = React.createClass
   displayName: 'LaptopAndMug'
-  getDefaultProps: ->
-    height: '388px'
+  propTypes:
+    height: React.PropTypes.number.isRequired
   render: ->
     {height} = @props
-    <svg x="0px" y="0px" width="100%" height={height} viewBox="-100 0 1140 388"
+    <svg x="0px" y="0px" width="100%" height={"#{height}px"} viewBox="-100 0 1140 388"
       preserveAspectRatio="xMidYMin slice" version="1.1" xmlns="http://www.w3.org/2000/svg">
 
       <g className='launcher-laptop'>
@@ -109,11 +109,11 @@ LaptopAndMug = React.createClass
 
 BackgroundAndDesk = React.createClass
   displayName: 'BackgroundAndDesk'
-  getDefaultProps: ->
-    height: '388px'
+  propTypes:
+    height: React.PropTypes.number.isRequired
   render: ->
     {height} = @props
-    <svg x="0px" y="0px" width="100%" height={height}
+    <svg x="0px" y="0px" width="100%" height={"#{height}px"}
       preserveAspectRatio="xMidYMin meet" version="1.1" xmlns="http://www.w3.org/2000/svg">
       <g>
         <rect className='launcher-background' y="0.541" fill="#E5E5E5" width="100%" height="100%"/>

--- a/src/task/index.cjsx
+++ b/src/task/index.cjsx
@@ -70,12 +70,6 @@ TaskBase = React.createClass
 
     @setState(nextState)
 
-  childContextTypes:
-    processHtmlAndMath: React.PropTypes.func
-
-  getChildContext: ->
-    processHtmlAndMath: @props.processHtmlAndMath
-
   render: ->
     {task, currentStep} = @state
     {taskId} = @props


### PR DESCRIPTION
Ensures that only one launcher is mounted before initializing another -- prevents additional listeners being added when webview is navigating back and forth between pages.  Also, simplifies some state stuffs in the `Launcher`
