### PR TITLE
progress no longer doubles the current page, clean up progress view

### DIFF
--- a/resources/styles/components/progress/index.less
+++ b/resources/styles/components/progress/index.less
@@ -19,10 +19,24 @@
   width: 100%;
 }
 
+.concept-coach-progress-section {
+  h1 {
+    font-weight: 100;
+    border-bottom: 1px solid @openstax-neutral-light;
+  }
+}
+
 .concept-coach-progress-chapter {
   h3 {
     line-height: 1.5em;
     border-bottom: 1px solid @openstax-neutral-light;
     margin-bottom: 0 !important;
+    font-weight: 100;
+  }
+
+  &.current {
+    h3 {
+      color: @openstax-info;
+    }
   }
 }

--- a/resources/styles/components/progress/page.less
+++ b/resources/styles/components/progress/page.less
@@ -17,6 +17,11 @@
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
+    font-weight: 600;
+
+    &::before {
+      font-weight: 200;
+    }
   }
 
   .concept-coach-progress-page-last-worked {

--- a/src/progress/chapter.cjsx
+++ b/src/progress/chapter.cjsx
@@ -12,6 +12,7 @@ ChapterProgress = React.createClass
   mixins: [ChapterSectionMixin]
   render: ->
     {chapter, className, maxLength} = @props
+    return null unless chapter.pages?.length > 0
 
     classes = classnames 'concept-coach-progress-chapter', className
     section = @sectionFormat(chapter.chapter_section)
@@ -26,10 +27,12 @@ ChapterProgress = React.createClass
         maxLength={maxLength}
         key={"progress-page-#{page.id}"}/>
 
+    title = <h3 {...sectionProps}>
+        {chapter.title}
+    </h3> if chapter.title?
+
     <div className={classes}>
-      <h3 {...sectionProps}>
-          {chapter.title}
-      </h3>
+      {title}
       <ul className='concept-coach-progress-pages'>
         {pages}
       </ul>

--- a/src/progress/collection.coffee
+++ b/src/progress/collection.coffee
@@ -1,4 +1,5 @@
 EventEmitter2 = require 'eventemitter2'
+_ = require 'underscore'
 api = require '../api'
 
 local = {}
@@ -23,7 +24,23 @@ fetch = (id) ->
 get = (id) ->
   local[id]
 
+getFilteredChapters = (id, uuids = []) ->
+  progresses = get(id)
+  return unless progresses?
+  {chapters} = progresses
+
+  _.chain(chapters)
+    .map((chapter) ->
+      chapter.pages = _.reject(chapter.pages, (page) ->
+        _.indexOf(uuids, page.uuid) > -1
+      )
+      return null if _.isEmpty chapter.pages
+      chapter
+    )
+    .compact()
+    .value()
+
 init = ->
   api.channel.on("#{apiChannelName}.*.receive.*", update)
 
-module.exports = {fetch, get, init, channel}
+module.exports = {fetch, get, getFilteredChapters, init, channel}

--- a/src/progress/current.cjsx
+++ b/src/progress/current.cjsx
@@ -10,29 +10,14 @@ apiChannelName = 'task'
 
 CurrentProgressBase = React.createClass
   displayName: 'CurrentProgressBase'
-  getInitialState: ->
-    {item} = @props
-
-    task: item
-
-  componentWillReceiveProps: (nextProps) ->
-    nextState =
-      task: nextProps.item
-
-    @setState(nextState)
-
   render: ->
-    {task} = @state
-    {taskId, maxLength, moduleUUID} = @props
+    {item, taskId, maxLength, moduleUUID} = @props
+    task = item
     return null unless task?.steps?
 
-    page = _.pick task, 'last_worked_at', 'id'
-    _.extend page, _.first(_.first(task.steps).related_content)
-    page.exercises = task.steps
-    page.uuid = moduleUUID
+    page = tasks.getAsPage(taskId)
 
     chapter =
-      title: 'Current'
       pages: [page]
 
     <ChapterProgress

--- a/src/progress/exercise.cjsx
+++ b/src/progress/exercise.cjsx
@@ -1,8 +1,5 @@
 React = require 'react'
-_ = require 'underscore'
 classnames = require 'classnames'
-
-{ChapterSectionMixin} = require 'openstax-react-components'
 
 ExerciseProgress = React.createClass
   displayName: 'ExerciseProgress'

--- a/src/progress/index.cjsx
+++ b/src/progress/index.cjsx
@@ -5,6 +5,7 @@ classnames = require 'classnames'
 {ChapterSectionMixin} = require 'openstax-react-components'
 {Reactive} = require '../reactive'
 {ExerciseButton} = require '../buttons'
+{SectionProgress} = require './section'
 {ChapterProgress} = require './chapter'
 {CurrentProgress} = require './current'
 {channel} = progresses = require './collection'
@@ -19,13 +20,13 @@ ProgressBase = React.createClass
   contextTypes:
     moduleUUID:     React.PropTypes.string
     collectionUUID: React.PropTypes.string
-  mixins: [ChapterSectionMixin]
   render: ->
     {item, className, status} = @props
     {moduleUUID, collectionUUID} = @context
 
+    chapters = item
     classes = classnames 'concept-coach-student-dashboard', className
-    chapters = _.clone(item.chapters) or []
+
     currentTask = tasks.get("#{collectionUUID}/#{moduleUUID}")
     maxExercises = _.chain(chapters)
       .pluck('pages')
@@ -45,16 +46,27 @@ ProgressBase = React.createClass
         key={"progress-chapter-#{chapter.id}"}/>
 
     <div className={classes}>
-      <CurrentProgress maxLength={maxLength}/>
-      {progress}
+      <SectionProgress title='Current Progress'>
+        <CurrentProgress maxLength={maxLength}/>
+      </SectionProgress>
+      <SectionProgress title='Previous'>
+        {progress}
+      </SectionProgress>
     </div>
 
 Progress = React.createClass
   displayName: 'Progress'
+  contextTypes:
+    moduleUUID:     React.PropTypes.string
   render: ->
     {id} = @props
+    {moduleUUID} = @context
 
-    <Reactive topic={id} store={progresses} apiChannelName={apiChannelName}>
+    <Reactive
+      topic={id}
+      getter={_.partial(progresses.getFilteredChapters, _, [moduleUUID])}
+      store={progresses}
+      apiChannelName={apiChannelName}>
       <ProgressBase/>
     </Reactive>
 

--- a/src/progress/section.cjsx
+++ b/src/progress/section.cjsx
@@ -1,0 +1,22 @@
+React = require 'react'
+classnames = require 'classnames'
+_ = require 'underscore'
+
+SectionProgress = React.createClass
+  displayName: 'SectionProgress'
+  getDefaultProps: ->
+    progress: null
+    title: 'Progress'
+  render: ->
+    {progress, title, children, className} = @props
+    progress ?= children
+    return null if _.isEmpty(progress)
+
+    classes = classnames 'concept-coach-progress-section', className
+
+    <div className={classes}>
+      <h1>{title}</h1>
+      {progress}
+    </div>
+
+module.exports = {SectionProgress}

--- a/src/reactive/index.cjsx
+++ b/src/reactive/index.cjsx
@@ -18,6 +18,7 @@ Reactive = React.createClass
     fetcher: React.PropTypes.func
     filter: React.PropTypes.func
     getStatusMessage: React.PropTypes.func
+    getter: React.PropTypes.func
 
   getDefaultProps: ->
     apiChannelPattern: '{apiChannelName}.{topic}.send.*'
@@ -42,13 +43,13 @@ Reactive = React.createClass
 
   getState: (eventData = {}, props) ->
     props ?= @props
-    {topic, store} = props
+    {topic, store, getter} = props
     {status} = eventData
     status ?= 'loaded'
 
     errors = eventData?.data?.errors
 
-    item: store.get?(topic)
+    item: getter?(topic) or store.get?(topic)
     status: status
     errors: errors
 

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -86,6 +86,17 @@ getModuleInfo = (taskId, cnxUrl = '') ->
 
   moduleInfo
 
+getAsPage = (taskId) ->
+  task = get(taskId)
+  {moduleUUID, steps} = task
+
+  page = _.pick task, 'last_worked_at', 'id'
+  _.extend page, _.first(_.first(steps).related_content)
+  page.exercises = steps
+  page.uuid = moduleUUID
+
+  page
+
 init = ->
   api.channel.on("task.*.receive.*", update)
   api.channel.on('task.*.receive.failure', checkFailure)
@@ -101,5 +112,6 @@ module.exports = {
   getFirstIncompleteIndex,
   getStepIndex,
   getModuleInfo,
+  getAsPage,
   channel
 }


### PR DESCRIPTION
## Before

![screen shot 2016-01-06 at 10 26 36 am](https://cloud.githubusercontent.com/assets/2483873/12147740/0f20679a-b460-11e5-8092-93e8420e1f1a.png)

![screen shot 2016-01-06 at 10 26 46 am](https://cloud.githubusercontent.com/assets/2483873/12147741/0f21399a-b460-11e5-9662-84e270598043.png)
## Now

![screen shot 2016-01-06 at 10 19 33 am](https://cloud.githubusercontent.com/assets/2483873/12147688/d97c780e-b45f-11e5-95f7-443678cc44de.png)

![screen shot 2016-01-06 at 10 19 21 am](https://cloud.githubusercontent.com/assets/2483873/12147689/d980f582-b45f-11e5-9f2f-e2cf7388d3b5.png)
