### PR TITLE
Fix 403 on user change

### DIFF
--- a/src/exercise/collection.coffee
+++ b/src/exercise/collection.coffee
@@ -5,7 +5,7 @@ steps = {}
 _ = require 'underscore'
 
 user = require '../user/model'
-user.channel.on 'change', ->
+user.channel.on 'logout.received', ->
   steps = {}
 
 channel = new EventEmitter2 wildcard: true

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -7,7 +7,7 @@ exercises = require '../exercise/collection'
 tasks = {}
 
 user = require '../user/model'
-user.channel.on 'change', ->
+user.channel.on 'logout.received', ->
   tasks = {}
 
 channel = new EventEmitter2 wildcard: true


### PR DESCRIPTION
So... we were clearing the stores on the user's `change` signal.  But the user model didn't actually fire that on logout.  

It did fire it when the courses changed and when it was updated though, which probably caused other bugs because the stores would be reset at random times. I suspect that this is the cause of the errors when a user registered for a course.
