### PR TITLE
Don't reset user event listeners on destroy()

### DIFF
--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -137,5 +137,9 @@ class Course
     delete @isBusy
     @channel.emit('change')
 
+  destroy: ->
+    @channel.emit('destroy')
+    @channel.removeAllListeners()
+
 
 module.exports = Course

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -91,12 +91,8 @@ User =
         User.channel.emit('change')
 
   destroy: ->
-    User.channel.removeAllListeners()
-
-    _.each @courses, (course) ->
-      course.channel.removeAllListeners()
-
-    _.extend(this, BLANK_USER)
+    _.invoke @courses, 'destroy'
+    @courses = []
 
 
 # start out as a blank user

--- a/test/task/collection.spec.coffee
+++ b/test/task/collection.spec.coffee
@@ -3,6 +3,7 @@
 {TaskReview} = require 'task/review'
 Collection = require 'task/collection'
 TASK = require 'cc/tasks/C_UUID/m_uuid/GET'
+User = require 'user/model'
 
 describe 'Task Collection', ->
 
@@ -26,3 +27,9 @@ describe 'Task Collection', ->
     expect(info).to.deep.equal(
       collectionUUID:"C_UUID", moduleUUID:"m_uuid", link:'test/contents/C_UUID:m_uuid'
     )
+
+
+  it 'is reset after user logs out', ->
+    expect( Collection.getModuleInfo(@taskId, 'test') ).not.to.be.undefined
+    User._signalLogoutCompleted()
+    expect( Collection.getModuleInfo(@taskId, 'test') ).to.be.undefined

--- a/test/user/model.spec.coffee
+++ b/test/user/model.spec.coffee
@@ -4,5 +4,21 @@ User = require 'user/model'
 
 describe 'User', ->
 
+
   it 'defaults to not logged in', ->
     expect(User.isLoggedIn()).to.be.false
+
+  it 'resets courses when destroy is called, but still emits signals', ->
+    fakeCourse =
+      destroy: -> true
+    sinon.stub(fakeCourse, 'destroy')
+    User.courses = [fakeCourse]
+    logoutSpy = sinon.spy()
+    User.channel.on 'logout.received', logoutSpy
+    User.destroy()
+    expect(User.courses).to.be.empty
+    expect(fakeCourse.destroy).to.have.been.called
+    expect(logoutSpy).not.to.have.been.called
+
+    User._signalLogoutCompleted()
+    expect(logoutSpy).to.have.been.called


### PR DESCRIPTION
I was on the fence about resetting the course listeners, but decided to leave that in, but moved it to the course/model.
