### PR TITLE
403 fix amendment

### DIFF
--- a/src/exercise/collection.coffee
+++ b/src/exercise/collection.coffee
@@ -5,8 +5,6 @@ steps = {}
 _ = require 'underscore'
 
 user = require '../user/model'
-user.channel.on 'logout.received', ->
-  steps = {}
 
 channel = new EventEmitter2 wildcard: true
 
@@ -57,6 +55,9 @@ get = (stepId) ->
   steps[stepId]
 
 init = ->
+  user.channel.on 'logout.received', ->
+    steps = {}
+
   api.channel.on("exercise.*.receive.*", update)
 
 module.exports = {fetch, getCurrentPanel, get, init, channel, quickLoad}

--- a/src/task/collection.coffee
+++ b/src/task/collection.coffee
@@ -7,8 +7,6 @@ exercises = require '../exercise/collection'
 tasks = {}
 
 user = require '../user/model'
-user.channel.on 'logout.received', ->
-  tasks = {}
 
 channel = new EventEmitter2 wildcard: true
 
@@ -99,6 +97,8 @@ getAsPage = (taskId) ->
   page
 
 init = ->
+  user.channel.on 'logout.received', ->
+    tasks = {}
   api.channel.on("task.*.receive.*", update)
   api.channel.on('task.*.receive.failure', checkFailure)
 

--- a/src/user/model.coffee
+++ b/src/user/model.coffee
@@ -91,6 +91,7 @@ User =
         User.channel.emit('change')
 
   destroy: ->
+    User.channel.removeAllListeners()
     _.invoke @courses, 'destroy'
     @courses = []
 

--- a/test/user/model.spec.coffee
+++ b/test/user/model.spec.coffee
@@ -8,7 +8,7 @@ describe 'User', ->
   it 'defaults to not logged in', ->
     expect(User.isLoggedIn()).to.be.false
 
-  it 'resets courses when destroy is called, but still emits signals', ->
+  it 'resets courses when destroy is called and can no longer emit signals', ->
     fakeCourse =
       destroy: -> true
     sinon.stub(fakeCourse, 'destroy')
@@ -21,4 +21,4 @@ describe 'User', ->
     expect(logoutSpy).not.to.have.been.called
 
     User._signalLogoutCompleted()
-    expect(logoutSpy).to.have.been.called
+    expect(logoutSpy).to.have.not.been.called


### PR DESCRIPTION
Follow up to @nathanstitt's #122

For cases when destroyed has been called, none of the listeners should fire.  However, task and exercises on init then need to be re-told to listen to the user.  That this should be done in kinda unclear currently, but the pattern is clean in #114 -- see:
- [Exercise initializes to listen to user logout](https://github.com/openstax/concept-coach/blob/update/base-model/src/exercise/collection.coffee#L16-L19)
- [Task initializes to listen to user logout](https://github.com/openstax/concept-coach/blob/update/base-model/src/task/collection.coffee#L24-L26)
- [Base model's destroy removes all listeners](https://github.com/openstax/concept-coach/blob/update/base-model/src/helpers/api-link.coffee#L208-L210) 
