### PR TITLE
takes out period from course name

### DIFF
--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -48,7 +48,7 @@ class Course
       msg = @describeMovePart(@to)
       if @from then "from #{@describeMovePart(@from)} to #{msg}" else msg
     else
-      "#{@name} #{_.first(@periods).name} period"
+      "#{@name} #{_.first(@periods).name}"
 
   describeMovePart: (part) ->
     return '' unless part

--- a/test/course/invite-code-input.spec.coffee
+++ b/test/course/invite-code-input.spec.coffee
@@ -16,7 +16,7 @@ describe 'InviteCodeInput Component', ->
     @props.optionalStudentId = true
     Testing.renderComponent( InviteCodeInput, props: @props ).then ({dom}) ->
       courses = _.pluck(dom.querySelectorAll('.list-group-item'), 'textContent')
-      expect(courses).to.deep.equal(['Biology I 1st period'])
+      expect(courses).to.deep.equal(['Biology I 1st'])
 
   it 'model registers when submit is clicked', ->
     sinon.stub(@props.course, 'register')


### PR DESCRIPTION
see also [this ticket](https://www.pivotaltracker.com/story/show/112365871)

Affects the follow, UI-wise:
![screen shot 2016-01-26 at 8 37 34 pm](https://cloud.githubusercontent.com/assets/2483873/12602192/e5e63bda-c46c-11e5-8750-f55d03187f31.png)
![screen shot 2016-01-26 at 8 39 06 pm](https://cloud.githubusercontent.com/assets/2483873/12602193/e5e8a366-c46c-11e5-9510-340969ea7fef.png)
