### PR TITLE
Change student identifier

### DIFF
--- a/resources/styles/components/course/index.less
+++ b/resources/styles/components/course/index.less
@@ -1,2 +1,3 @@
 @import './item';
+@import './student_id';
 @import './registration';

--- a/resources/styles/components/course/student_id.less
+++ b/resources/styles/components/course/student_id.less
@@ -5,10 +5,8 @@
     margin: 0 auto;
     display: flex;
     align-items: flex-end;
-    .form-group {margin: 0;}
-    .field {
-      height: 80px;
-    }
+    .form-group { margin: 0; }
+    .field  { height: 80px; }
     .cancel {
       margin-left: 20px;
       padding-left: 20px;

--- a/resources/styles/components/course/student_id.less
+++ b/resources/styles/components/course/student_id.less
@@ -1,0 +1,29 @@
+.request-student-id {
+  .panels {
+    width: 60%;
+    @media (max-width: @screen-sm-min){ width: 95%; }
+    margin: 0 auto;
+    display: flex;
+    align-items: flex-end;
+    .form-group {margin: 0;}
+    .field {
+      height: 80px;
+    }
+    .cancel {
+      margin-left: 20px;
+      padding-left: 20px;
+      border-left: 1px solid @openstax-neutral-light;
+      align-self: stretch;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      .btn {
+        background-color: white;
+        transition: background-color 200ms linear;
+        &:hover {
+          background-color: @openstax-neutral-lighter;
+        }
+      }
+    }
+  }
+}

--- a/src/api/settings.coffee
+++ b/src/api/settings.coffee
@@ -57,4 +57,10 @@ settings =
       failedEvent: 'course.{id}.receive.confirmation.failure'
       completedEvent: 'course.{id}.receive.confirmation.complete'
 
+    'course.*.send.studentUpdate':
+      url: 'api/user/courses/{id}/student'
+      method: 'PATCH'
+      failedEvent: 'course.*.send.studentUpdate.failure'
+      completedEvent: 'course.*.receive.studentUpdate.complete'
+
 module.exports = settings

--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -150,8 +150,6 @@ ConceptCoach = React.createClass
 
   childComponent: (course) ->
     {view} = @state
-    course = User.getCourse(@props.collectionUUID)
-
     switch view
       when 'loading'
         <span><i className='fa fa-spinner fa-spin'/> Loading ...</span>

--- a/src/concept-coach/base.cjsx
+++ b/src/concept-coach/base.cjsx
@@ -11,6 +11,7 @@ navigation = {Navigation} = require '../navigation'
 CourseRegistration = require '../course/registration'
 ErrorNotification = require './error-notification'
 AccountsIframe = require '../user/accounts-iframe'
+UpdateStudentIdentifier = require '../course/update-student-identifier'
 LoginGateway = require '../user/login-gateway'
 User = require '../user/model'
 
@@ -23,7 +24,7 @@ navigator = navigation.channel
 
 # TODO Move this and auth logic to user model
 # These views are used with an authLevel (0, 1, 2, or 3) to determine what views the user is allowed to see.
-VIEWS = ['loading', 'login', 'registration', ['task', 'progress', 'profile', 'dashboard', 'registration'], 'logout']
+VIEWS = ['loading', 'login', 'registration', ['task', 'progress', 'profile', 'dashboard', 'registration', 'student_id'], 'logout']
 
 ConceptCoach = React.createClass
   displayName: 'ConceptCoach'
@@ -147,7 +148,7 @@ ConceptCoach = React.createClass
 
     @setState(userState)
 
-  childComponent: ->
+  childComponent: (course) ->
     {view} = @state
     course = User.getCourse(@props.collectionUUID)
 
@@ -170,6 +171,8 @@ ConceptCoach = React.createClass
         <AccountsIframe type='profile' onComplete={@updateUser} />
       when 'registration'
         <CourseRegistration {...@props} />
+      when 'student_id'
+        <UpdateStudentIdentifier {...@props} course={course} />
       else
         <h3 className="error">bad internal state, no view is set</h3>
 
@@ -186,7 +189,7 @@ ConceptCoach = React.createClass
       <SpyMode.Wrapper>
         <Navigation key='user-status' close={@props.close} course={course}/>
         <div className={className}>
-          {@childComponent()}
+          {@childComponent(course)}
         </div>
       </SpyMode.Wrapper>
     </div>

--- a/src/course/confirm-join.cjsx
+++ b/src/course/confirm-join.cjsx
@@ -1,6 +1,7 @@
 React = require 'react'
 BS = require 'react-bootstrap'
 ENTER = 'Enter'
+RequestStudentId = require './request-student-id'
 
 Course = require './model'
 ErrorList = require './error-list'
@@ -13,17 +14,11 @@ ConfirmJoin = React.createClass
     course: React.PropTypes.instanceOf(Course).isRequired
     optionalStudentId: React.PropTypes.bool
 
-  startConfirmation: ->
-    @props.course.confirm(@refs.input.getValue())
-
-  onKeyPress: (ev) ->
-    @startConfirmation() if ev.key is ENTER
-
-  onConfirmKeyPress: (ev) ->
-    @startConfirmation() if ev.key is ENTER
-
-  cancelConfirmation: ->
+  onCancel: ->
     @props.course.resetToBlankState()
+
+  startConfirmation: (studentId) ->
+    @props.course.confirm(studentId)
 
   render: ->
     label = if @props.optionalStudentId
@@ -34,33 +29,18 @@ ConfirmJoin = React.createClass
     else
       "Enter your school issued ID:"
 
-    <div className="form-group">
-      <h3 className="text-center">
-        {@props.title}
-      </h3>
-      <ErrorList course={@props.course} />
-      <div className="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-12">
+    <BS.Row>
+      <RequestStudentId
 
-        <BS.Input type="text" ref="input" label={label}
-          placeholder="School issued ID" autoFocus
-          onKeyPress={@onKeyPress}
-        />
+        onCancel={@onCancel}
+        onSubmit={@startConfirmation}
+        saveButtonLabel="Confirm"
+        canCancel={true}
 
-        <div className="text-center">
-          <button className="btn"
-            onClick={@cancelConfirmation}>Cancel</button>
-
-           <AsyncButton
-             className="btn btn-success"
-             isWaiting={!!@props.course.isBusy}
-             waitingText={'Confirming…'}
-             onClick={@startConfirmation}
-             style={marginLeft: '3rem'}
-           >
-            Confirm
-          </AsyncButton>
-        </div>
-      </div>
-    </div>
+        label={label}
+        onConfirmationCancel={@onCancel}
+        {...@props}
+      />
+    </BS.Row>
 
 module.exports = ConfirmJoin

--- a/src/course/confirm-join.cjsx
+++ b/src/course/confirm-join.cjsx
@@ -31,12 +31,9 @@ ConfirmJoin = React.createClass
 
     <BS.Row>
       <RequestStudentId
-
         onCancel={@onCancel}
         onSubmit={@startConfirmation}
         saveButtonLabel="Confirm"
-        canCancel={true}
-
         label={label}
         onConfirmationCancel={@onCancel}
         {...@props}

--- a/src/course/model.coffee
+++ b/src/course/model.coffee
@@ -24,7 +24,7 @@ class Course
   constructor: (attributes) ->
     @channel = new EventEmitter2
     _.extend(@, attributes)
-    _.bindAll(@, '_onRegistered', '_onConfirmed', '_onValidated')
+    _.bindAll(@, '_onRegistered', '_onConfirmed', '_onValidated', '_onStudentUpdated')
 
   # complete and ready for use
   isRegistered: -> @id and not (@isIncomplete() or @isPending())
@@ -125,6 +125,15 @@ class Course
       api.channel.once "course.#{@ecosystem_book_uuid}.receive.prevalidation.*", @_onValidated
       api.channel.emit("course.#{@ecosystem_book_uuid}.send.prevalidation", {data})
     @channel.emit('change')
+
+  _onStudentUpdated: (response) ->
+    _.extend(@, response.data) if response?.data
+    @channel.emit('change')
+
+  updateStudent: (attributes) ->
+    data = _.extend({}, attributes, id: @id)
+    api.channel.once "course.#{@ecosystem_book_uuid}.receive.studentUpdate.*", @_onStudentUpdated
+    api.channel.emit("course.#{@ecosystem_book_uuid}.send.studentUpdate", {data})
 
   _onRegistered: (response) ->
     throw new Error("response is empty in onRegistered") if _.isEmpty(response)

--- a/src/course/modify-registration.cjsx
+++ b/src/course/modify-registration.cjsx
@@ -2,8 +2,9 @@ React = require 'react'
 _ = require 'underscore'
 
 InviteCodeInput = require './invite-code-input'
-ConfirmJoin = require './confirm-join'
+RequestStudentId = require './request-student-id'
 
+ConfirmJoin = require './confirm-join'
 User = require '../user/model'
 Course = require './model'
 Navigation = require '../navigation/model'
@@ -48,7 +49,9 @@ ModifyCourseRegistration = React.createClass
         course={course}
         title={"Leave #{original.description()} for new course/period"} />
     else if course.isPending()
-      <ConfirmJoin course={course} optionalStudentId
+      <ConfirmJoin
+        course={course}
+        optionalStudentId
         title={"Are you sure you want to switch your registration #{course.description()}?"}
       />
     else

--- a/src/course/request-student-id.cjsx
+++ b/src/course/request-student-id.cjsx
@@ -27,7 +27,7 @@ RequestStudentId = React.createClass
     @props.onSubmit(@refs.input.getValue())
 
   renderCancel: ->
-    <div className="col-sm-2">
+    <div className="cancel">
       <button className="btn"
         onClick={@props.onCancel}>Cancel</button>
     </div>
@@ -41,20 +41,22 @@ RequestStudentId = React.createClass
         onClick={@onSubmit}
       >{@props.saveButtonLabel}</AsyncButton>
 
-    <div className="form-group">
+    <div className="request-student-id form-group">
       <h3 className="text-center">
         {@props.title}
       </h3>
       <ErrorList course={@props.course} />
-      <div className="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-12">
+      <div className='panels'>
+        <div className='field'>
 
-        <BS.Input type="text" ref="input" label={@props.label}
-          placeholder="School issued ID" autoFocus
-          onKeyPress={@onKeyPress}
-          buttonAfter={button} />
+          <BS.Input type="text" ref="input" label={@props.label}
+            placeholder="School issued ID" autoFocus
+            onKeyPress={@onKeyPress}
+            buttonAfter={button} />
 
-      </div>
+        </div>
         {@renderCancel() if @props.canCancel}
+      </div>
     </div>
 
 module.exports = RequestStudentId

--- a/src/course/request-student-id.cjsx
+++ b/src/course/request-student-id.cjsx
@@ -11,11 +11,13 @@ RequestStudentId = React.createClass
   propTypes:
     onCancel: React.PropTypes.func.isRequired
     onSubmit: React.PropTypes.func.isRequired
-    label: React.PropTypes.string.isRequired
+    label: React.PropTypes.oneOfType([
+      React.PropTypes.string
+      React.PropTypes.element
+    ]).isRequired
     saveButtonLabel: React.PropTypes.string.isRequired
     title: React.PropTypes.string.isRequired
     course: React.PropTypes.instanceOf(Course).isRequired
-    optionalStudentId: React.PropTypes.bool
 
   startConfirmation: ->
     @props.course.confirm(@refs.input.getValue())

--- a/src/course/request-student-id.cjsx
+++ b/src/course/request-student-id.cjsx
@@ -26,12 +26,6 @@ RequestStudentId = React.createClass
   onSubmit: ->
     @props.onSubmit(@refs.input.getValue())
 
-  renderCancel: ->
-    <div className="cancel">
-      <button className="btn"
-        onClick={@props.onCancel}>Cancel</button>
-    </div>
-
   render: ->
     button =
       <AsyncButton
@@ -48,14 +42,15 @@ RequestStudentId = React.createClass
       <ErrorList course={@props.course} />
       <div className='panels'>
         <div className='field'>
-
           <BS.Input type="text" ref="input" label={@props.label}
             placeholder="School issued ID" autoFocus
             onKeyPress={@onKeyPress}
             buttonAfter={button} />
-
         </div>
-        {@renderCancel() if @props.canCancel}
+        <div className="cancel">
+          <button className="btn"
+            onClick={@props.onCancel}>Cancel</button>
+        </div>
       </div>
     </div>
 

--- a/src/course/request-student-id.cjsx
+++ b/src/course/request-student-id.cjsx
@@ -1,0 +1,60 @@
+React = require 'react'
+BS = require 'react-bootstrap'
+ENTER = 'Enter'
+
+Course = require './model'
+ErrorList = require './error-list'
+{AsyncButton} = require 'openstax-react-components'
+
+RequestStudentId = React.createClass
+
+  propTypes:
+    onCancel: React.PropTypes.func.isRequired
+    onSubmit: React.PropTypes.func.isRequired
+    label: React.PropTypes.string.isRequired
+    saveButtonLabel: React.PropTypes.string.isRequired
+    title: React.PropTypes.string.isRequired
+    course: React.PropTypes.instanceOf(Course).isRequired
+    optionalStudentId: React.PropTypes.bool
+
+  startConfirmation: ->
+    @props.course.confirm(@refs.input.getValue())
+
+  onKeyPress: (ev) ->
+    @onSubmit() if ev.key is ENTER
+
+  onSubmit: ->
+    @props.onSubmit(@refs.input.getValue())
+
+  renderCancel: ->
+    <div className="col-sm-2">
+      <button className="btn"
+        onClick={@props.onCancel}>Cancel</button>
+    </div>
+
+  render: ->
+    button =
+      <AsyncButton
+        className="btn btn-success"
+        isWaiting={!!@props.course.isBusy}
+        waitingText={'Confirming…'}
+        onClick={@onSubmit}
+      >{@props.saveButtonLabel}</AsyncButton>
+
+    <div className="form-group">
+      <h3 className="text-center">
+        {@props.title}
+      </h3>
+      <ErrorList course={@props.course} />
+      <div className="col-md-6 col-md-offset-3 col-sm-8 col-sm-offset-2 col-xs-12">
+
+        <BS.Input type="text" ref="input" label={@props.label}
+          placeholder="School issued ID" autoFocus
+          onKeyPress={@onKeyPress}
+          buttonAfter={button} />
+
+      </div>
+        {@renderCancel() if @props.canCancel}
+    </div>
+
+module.exports = RequestStudentId

--- a/src/course/update-student-identifier.cjsx
+++ b/src/course/update-student-identifier.cjsx
@@ -1,0 +1,72 @@
+_ = require 'underscore'
+React = require 'react'
+BS = require 'react-bootstrap'
+{AsyncButton} = require 'openstax-react-components'
+ENTER = 'Enter'
+
+Course = require './model'
+ErrorList = require './error-list'
+RequestStudentId = require './request-student-id'
+Navigation = require '../navigation/model'
+
+UpdateStudentIdentifer = React.createClass
+  componentWillMount: ->
+    course = @props.course or
+      User.getCourse(@props.collectionUUID) or
+      new Course({ecosystem_book_uuid: @props.collectionUUID})
+    course.channel.on('change', @onCourseChange)
+    @setState({course})
+
+  componentWillUnmount: ->
+    @state.course.channel.off('change', @onCourseChange)
+
+  onCourseChange: ->
+    if @props.course.student_identifier
+      @setState(requestSuccess: true)
+      delete @props.course.student_identifier
+      # wait 1.5 secs so our success message is briefly displayed, then call onComplete
+      _.delay(@onCancel, 1500)
+    @forceUpdate()
+
+  propTypes:
+    course: React.PropTypes.instanceOf(Course).isRequired
+
+  startConfirmation: ->
+    @props.course.confirm(@refs.input.getValue())
+
+  onKeyPress: (ev) ->
+    @startConfirmation() if ev.key is ENTER
+
+  onConfirmKeyPress: (ev) ->
+    @startConfirmation() if ev.key is ENTER
+
+  cancelConfirmation: ->
+    @props.course.resetToBlankState()
+
+  onSubmit: (studentId) ->
+    @props.course.updateStudent(student_identifier: studentId)
+
+  onCancel: ->
+    Navigation.channel.emit('show.task', view: 'task')
+
+  renderComplete: ->
+    <h3 className="text-center">
+      You have successfully updated your student identifier.
+    </h3>
+
+  render: ->
+    return @renderComplete() if @state.requestSuccess
+
+    <BS.Row>
+      <RequestStudentId
+        label="Enter your school issued ID:"
+        title="Change your student ID"
+        onCancel={@onCancel}
+        onSubmit={@onSubmit}
+        saveButtonLabel="Save"
+        canCancel={true}
+        {...@props}
+      />
+    </BS.Row>
+
+module.exports = UpdateStudentIdentifer

--- a/src/navigation/settings.coffee
+++ b/src/navigation/settings.coffee
@@ -10,6 +10,7 @@ settings =
     progress: DEFAULT_PATTERN
     loading: DEFAULT_PATTERN
     login: DEFAULT_PATTERN
+    student_id: DEFAULT_PATTERN
     logout: DEFAULT_PATTERN
     default: '{prefix}{base}'
     close: '{prefix}'

--- a/src/user/menu.cjsx
+++ b/src/user/menu.cjsx
@@ -33,6 +33,10 @@ UserMenu = React.createClass
     clickEvent.preventDefault()
     @context.navigator.emit('show.profile', view: 'profile')
 
+  updateStudentId: (clickEvent) ->
+    clickEvent.preventDefault()
+    @context.navigator.emit('show.student_id', view: 'student_id')
+
   update: ->
     @forceUpdate() if @isMounted()
 
@@ -46,10 +50,14 @@ UserMenu = React.createClass
 
   renderCourseOption: ->
     if @props.course?.isRegistered()
-      courseChangeText = 'Change Course and ID'
+      courseChangeText = 'Change Course'
     else
       courseChangeText = 'Register for Course'
     <BS.MenuItem onClick={@modifyCourse}>{courseChangeText}</BS.MenuItem>
+
+  renderStudentIdOption: ->
+    return null unless @props.course?.isRegistered()
+    <BS.MenuItem onClick={@updateStudentId}>Change student ID</BS.MenuItem>
 
   render: ->
     # The menu has no valid actions unless the useris logged in
@@ -58,6 +66,7 @@ UserMenu = React.createClass
     <BS.DropdownButton navItem className='concept-coach-user' title={user.name}>
       {@renderCourseOption()}
       <BS.MenuItem onClick={@showProfile}>Account Profile</BS.MenuItem>
+      {@renderStudentIdOption()}
       <BS.MenuItem onClick={@logoutUser}>Logout</BS.MenuItem>
     </BS.DropdownButton>
 

--- a/test/course/request-student-id.spec.coffee
+++ b/test/course/request-student-id.spec.coffee
@@ -1,0 +1,34 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require 'openstax-react-components/test/helpers'
+
+Course = require 'course/model'
+RequestStudentId = require 'course/request-student-id'
+
+describe 'RequestStudentId Component', ->
+
+  beforeEach ->
+    @props =
+      onCancel: sinon.spy()
+      onSubmit: sinon.spy()
+      label: 'a test label'
+      saveButtonLabel: 'this is save btn'
+      title: 'this is title'
+      course: new Course(ecosystem_book_uuid: 'test-collection-uuid')
+
+  it 'renders values from props', ->
+    Testing.renderComponent( RequestStudentId, props: @props ).then ({dom}) =>
+      expect(dom.querySelector('h3').textContent).to.equal(@props.title)
+      expect(dom.querySelector('.control-label').textContent).to.equal(@props.label)
+      expect(dom.querySelector('.btn-default').textContent).to.equal(@props.saveButtonLabel)
+
+  it 'calls onSubmit when save button is clicked', ->
+    Testing.renderComponent( RequestStudentId, props: @props ).then ({dom}) =>
+      expect(@props.onSubmit).not.to.have.been.called
+      dom.querySelector('input').value = 'test value'
+      Testing.actions.click(dom.querySelector('.btn-default'))
+      expect(@props.onSubmit).to.have.been.calledWith('test value')
+
+  it 'calls onCancel when cancel button is clicked', ->
+    Testing.renderComponent( RequestStudentId, props: @props ).then ({dom}) =>
+      expect(@props.onCancel).not.to.have.been.called
+      Testing.actions.click(dom.querySelector('.cancel .btn'))
+      expect(@props.onCancel).to.have.been.called

--- a/test/course/update-student-identifier.spec.coffee
+++ b/test/course/update-student-identifier.spec.coffee
@@ -1,0 +1,29 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require 'openstax-react-components/test/helpers'
+
+Course = require 'course/model'
+
+UpdateStudentIdentifier = require 'course/update-student-identifier'
+
+describe 'UpdateStudentIdentifier Component', ->
+
+  beforeEach ->
+    @props =
+      course: new Course(ecosystem_book_uuid: 'test-collection-uuid')
+
+  it 'submits a request when form is filled out', ->
+    sinon.stub(@props.course, 'updateStudent')
+    Testing.renderComponent( UpdateStudentIdentifier, props: @props ).then ({dom}) =>
+      dom.querySelector('input').value = 'test value'
+      Testing.actions.click(dom.querySelector('.btn-default'))
+      expect(@props.course.updateStudent).to.have.been.calledWith(student_identifier: 'test value')
+
+  it 'updates when a successful response is recieved',  (done) ->
+    sinon.stub(@props.course, 'updateStudent', (id) ->
+      @_onStudentUpdated({data: {student_identifier: id}})
+    )
+    Testing.renderComponent( UpdateStudentIdentifier, props: @props ).then ({element, dom}) ->
+      dom.querySelector('input').value = 'new id'
+      Testing.actions.click(dom.querySelector('.btn-default'))
+      _.defer ->
+        expect(element.getDOMNode().textContent).to.match(/You have successfully updated your student identifier/)
+        done()

--- a/test/user/menu.spec.coffee
+++ b/test/user/menu.spec.coffee
@@ -26,4 +26,5 @@ describe 'User menu component', ->
     it 'renders modification when registered', ->
       sinon.stub(@props.course, 'isRegistered').returns(true)
       Testing.renderComponent( Menu, props: @props ).then ({dom}) ->
-        expect(dom.textContent).to.match(/Change Course and ID/)
+        expect(dom.textContent).to.match(/Change Course/)
+        expect(dom.textContent).to.match(/Change student ID/)


### PR DESCRIPTION
Uses new BE PR https://github.com/openstax/tutor-server/pull/967

This extracts the "enter student id" logic into a new `RequestStudentId` component and uses that for both new/modify registration and the new change id screen.

Note the mockup in pivotal shows the old student identifier but we don't have that information to display.

TODO:
- [x] styling
- [x] specs

![screen shot 2016-02-04 at 3 41 41 pm](https://cloud.githubusercontent.com/assets/79566/12830724/5eb5dc1a-cb56-11e5-90f5-05467a8786d6.png)
![screen shot 2016-02-04 at 3 41 05 pm](https://cloud.githubusercontent.com/assets/79566/12830723/5eb2a13a-cb56-11e5-8aa6-8a4640cc1d3e.png)
