### PR TITLE
:package: Script "build for release" process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
+/assets/demo
+/assets/main
 *.orig
 /.tmp
-/dist
-/assets
 /test-failed-*.png

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /node_modules
-/assets/demo
-/assets/main
 *.orig
 /.tmp
+/dist
+/assets
 /test-failed-*.png

--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -55,7 +55,7 @@ gulp.task '_buildDemo', _.partial(gulpWebpack, 'demo')
 
 gulp.task 'build', ['_cleanDist', '_buildMain', '_buildMainMin', '_buildFull', '_buildFullMin']
 
-gulp.task '_tagRev', ['_build'], ->
+gulp.task '_tagRev', ['build'], ->
   gulp.src("#{DIST_DIR}/*.min.*")
     .pipe(rev())
     .pipe(gulp.dest(DIST_DIR))

--- a/Gulpfile.coffee
+++ b/Gulpfile.coffee
@@ -53,7 +53,7 @@ gulp.task '_buildFull', _.partial(gulpWebpack, 'fullBuild')
 gulp.task '_buildFullMin', _.partial(gulpWebpack, 'fullBuild.min')
 gulp.task '_buildDemo', _.partial(gulpWebpack, 'demo')
 
-gulp.task '_build', ['_cleanDist', '_buildMain', '_buildMainMin', '_buildFull', '_buildFullMin']
+gulp.task 'build', ['_cleanDist', '_buildMain', '_buildMainMin', '_buildFull', '_buildFullMin']
 
 gulp.task '_tagRev', ['_build'], ->
   gulp.src("#{DIST_DIR}/*.min.*")
@@ -128,3 +128,5 @@ gulp.task 'testrunner', ->
 gulp.task 'tdd', ['_cleanDist', '_webserver', 'testrunner']
 
 gulp.task 'demo', ['_buildDemo']
+
+gulp.task 'release', ['build', 'demo']

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 See it [here](https://openstax.github.io/concept-coach/).
 
 # To run locally:
@@ -13,3 +12,11 @@ you need to have [tutor-server](https://github.com/openstax/tutor-server) runnin
   * Starts around line 20.
 1. Restart the `tutor-server`
 1. Go to `http://localhost:3004` and the Launch button for Concept Coach should be there!
+
+
+# To build for release and deployment:
+
+1. Run `npm release`
+  * This will switch to gh-pages branch, merge master into it, and then build
+1. Commit files and push to github gh-pages branch
+1. Copy sha hash of commit into webview's `bower.json`

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "test": "gulp test && gulp prod",
     "coverage": "gulp coverage",
+    "release": "./release.sh",
     "deployment": "gulp prod",
     "test-integration": "mocha -R spec ./test-integration/",
     "start": "gulp dev"

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+git checkout gh-pages
+
+git merge master -m 'merge master in prep for release'
+
+npm install
+
+gulp release
+
+echo "Done with build, git commit and/or tag and push to complete"


### PR DESCRIPTION
Last time I ran the steps I missed the `npm install` step.  This should prevent errors like that from happening in future.

It could probably be cleaned up further but is better than manually running the steps :grin: 
