### PR TITLE
Display cancel button on student id update screen

### DIFF
--- a/resources/styles/components/course/student_id.less
+++ b/resources/styles/components/course/student_id.less
@@ -16,7 +16,6 @@
       flex-direction: column;
       justify-content: center;
       .btn {
-        background-color: white;
         transition: background-color 200ms linear;
         &:hover {
           background-color: @openstax-neutral-lighter;

--- a/resources/styles/components/course/student_id.less
+++ b/resources/styles/components/course/student_id.less
@@ -15,11 +15,10 @@
       display: flex;
       flex-direction: column;
       justify-content: center;
-      .btn {
-        transition: background-color 200ms linear;
-        &:hover {
-          background-color: @openstax-neutral-lighter;
-        }
+      a {
+        border-bottom: 0;
+        color: @link-color;
+        &:hover{ color: darken(@link-color, 20%); }
       }
     }
   }

--- a/src/course/request-student-id.cjsx
+++ b/src/course/request-student-id.cjsx
@@ -26,6 +26,10 @@ RequestStudentId = React.createClass
   onKeyPress: (ev) ->
     @onSubmit() if ev.key is ENTER
 
+  onCancel: (ev) ->
+    ev.preventDefault()
+    @props.onCancel()
+
   onSubmit: ->
     @props.onSubmit(@refs.input.getValue())
 
@@ -52,8 +56,7 @@ RequestStudentId = React.createClass
             buttonAfter={button} />
         </div>
         <div className="cancel">
-          <button className="btn"
-            onClick={@props.onCancel}>Cancel</button>
+          <a href='#' onClick={@onCancel}>Cancel</a>
         </div>
       </div>
     </div>

--- a/test/course/request-student-id.spec.coffee
+++ b/test/course/request-student-id.spec.coffee
@@ -30,5 +30,5 @@ describe 'RequestStudentId Component', ->
   it 'calls onCancel when cancel button is clicked', ->
     Testing.renderComponent( RequestStudentId, props: @props ).then ({dom}) =>
       expect(@props.onCancel).not.to.have.been.called
-      Testing.actions.click(dom.querySelector('.cancel .btn'))
+      Testing.actions.click(dom.querySelector('.cancel a'))
       expect(@props.onCancel).to.have.been.called


### PR DESCRIPTION
Previously the cancel button had a white background which made it invisible until mouse was hovered. This update only removes the white color, leaving the button grey.  @openstax/ux may want a different style for the button?

It's appearance:
![screen shot 2016-03-14 at 5 10 35 pm](https://cloud.githubusercontent.com/assets/79566/13761611/b2f1f0e6-ea07-11e5-8651-1ac5d688bf1e.png)
