### PR TITLE
matching update for FR caching with answer button fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#fb1a120",
+    "openstax-react-components": "openstax/react-components#d-20160318.a.candidate",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#d-20160318.a.candidate",
+    "openstax-react-components": "openstax/react-components#d-20160322.a",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/test/exercise/index.spec.coffee
+++ b/test/exercise/index.spec.coffee
@@ -62,4 +62,5 @@ describe 'Exercise Step', ->
       input = answer.querySelector('input')
       ReactTestUtils.Simulate.change(input, target:{checked: true})
       Testing.actions.click(input)
-      expect(@props.item.answer_id).equal(step.content.questions[0].answers[0].id)
+      selectedAnswer = _.find(step.content.questions[0].answers, id: @props.item.answer_id)
+      expect(selectedAnswer.content_html).equal(answer.innerText)


### PR DESCRIPTION
 from openstax/react-components#49, should do a quick update after it's merged with the official tag
