### PR TITLE
Load and display system notifications

### DIFF
--- a/api/notifications/GET.json
+++ b/api/notifications/GET.json
@@ -1,0 +1,7 @@
+[{
+  "id": "1",
+  "message": "Warning: Updates will happen soon!  Site will be down."
+}, {
+  "id": "2",
+  "message": "These are test messages."
+}]

--- a/resources/styles/components/navigation/index.less
+++ b/resources/styles/components/navigation/index.less
@@ -1,3 +1,5 @@
+@import "./notifications-bar";
+
 .concept-coach {
 
   .navbar-brand {
@@ -31,4 +33,6 @@
   .navbar .dropdown-menu > li > a {
     text-decoration: none;
   }
+
+
 }

--- a/resources/styles/components/navigation/notifications-bar.less
+++ b/resources/styles/components/navigation/notifications-bar.less
@@ -1,0 +1,32 @@
+.concept-coach {
+  .notifications-bar {
+    position: absolute;
+    left: 0;
+    right: 0;
+    background-color: @openstax-primary;
+    padding-left: 4rem;
+    .notification {
+      display: flex;
+      flex-direction: row;
+      justify-content: flex-start;
+      align-items: center;
+      color: @openstax-neutral-lighter;
+      padding: 15px;
+      font-size: 2rem;
+
+      & + .notification {
+        border-top: 1px solid darken(@openstax-primary, 5%);
+      }
+      .icon {
+        margin-right: 1rem;
+        font-size: 3rem;
+      }
+      .dismiss {
+        color: @openstax-neutral-lighter;
+        cursor: pointer;
+        font-size: 1.8rem;
+        margin-left: 1rem;
+      }
+    }
+  }
+}

--- a/src/api/settings.coffee
+++ b/src/api/settings.coffee
@@ -63,4 +63,11 @@ settings =
       failedEvent: 'course.*.send.studentUpdate.failure'
       completedEvent: 'course.*.receive.studentUpdate.complete'
 
+    'notifications.send.fetch':
+      url: 'api/notifications'
+      method: 'GET'
+      failedEvent: 'notifications.fetch.failure'
+      completedEvent: 'notifications.fetch.complete'
+
+
 module.exports = settings

--- a/src/concept-coach/index.cjsx
+++ b/src/concept-coach/index.cjsx
@@ -10,6 +10,7 @@ User = require '../user/model'
 exercise = require '../exercise/collection'
 progress = require '../progress/collection'
 task = require '../task/collection'
+notifications = require '../navigation/notifications-model'
 
 {Coach} = require './coach'
 coachWrapped = helpers.wrapComponent(Coach)
@@ -83,7 +84,7 @@ class ConceptCoachAPI extends EventEmitter2
     restAPI.init = _.partial restAPI.initialize, baseUrl
     navigation.init = _.partial navigation.initialize, navOptions
 
-    @models = [restAPI, navigation, User, exercise, progress, task, componentModel]
+    @models = [restAPI, navigation, User, exercise, progress, task, componentModel, notifications]
     initializeModels(@models)
 
     listenAndBroadcast(@)

--- a/src/navigation/index.cjsx
+++ b/src/navigation/index.cjsx
@@ -8,6 +8,7 @@ user = require '../user/model'
 {channel} = require './model'
 api = require '../api'
 UserMenu = require '../user/menu'
+NotificationsBar = require './notifications-bar'
 
 Navigation = React.createClass
   displayName: 'Navigation'
@@ -66,6 +67,7 @@ Navigation = React.createClass
           </BS.NavItem>
         </BS.Nav>
       </BS.CollapsibleNav>
+      <NotificationsBar />
     </BS.Navbar>
 
 module.exports = {Navigation, channel}

--- a/src/navigation/notifications-bar.cjsx
+++ b/src/navigation/notifications-bar.cjsx
@@ -1,0 +1,43 @@
+React = require 'react'
+_ = require 'underscore'
+Notifications = require './notifications-model'
+
+Notification = React.createClass
+  propTypes:
+    notice: React.PropTypes.shape(
+      id: React.PropTypes.string.isRequired
+      message: React.PropTypes.string.isRequired
+    ).isRequired
+
+  acknowledge: ->
+    Notifications.acknowledge(@props.notice.id)
+
+  render: ->
+    <div className="notification">
+      <i className='icon fa fa-info-circle'/>
+      {@props.notice.message}
+      <a className='dismiss' onClick={@acknowledge}>Dismiss</a>
+    </div>
+
+
+NotificationBar = React.createClass
+
+  componentWillMount: ->
+    Notifications.channel.on('change', @onNoticeChange)
+
+  componentWillUnmount: ->
+    Notifications.channel.off('change', @onNoticeChange)
+
+  onNoticeChange: -> @forceUpdate()
+
+  render: ->
+    notifications = Notifications.getActive()
+    return null if _.isEmpty(notifications)
+
+    <div className="notifications-bar">
+      {for notice in notifications
+        <Notification key={notice.id} notice={notice} />}
+    </div>
+
+
+module.exports = NotificationBar

--- a/src/navigation/notifications-model.coffee
+++ b/src/navigation/notifications-model.coffee
@@ -5,13 +5,13 @@ api = require '../api'
 POLL_INTERVAL = 5 * 60 * 1000 # 5 minutes
 STORAGE_KEY   = 'ox-cc-notifications'
 WINDOW = window
+POLLING = null
 
 pollForUpdate = ->
   api.channel.emit('notifications.send.fetch') unless window.document.hidden is true
 
 channel = new EventEmitter2
 
-polling = null
 
 activeNotifications = {}
 
@@ -56,15 +56,17 @@ loaded = (resp) ->
 destroy = (windowImpl = window) ->
   WINDOW = windowImpl
   activeNotifications = {}
-  WINDOW.clearInterval(polling) if polling
+  api.channel.off 'notifications.fetch.*', loaded
+  WINDOW.clearInterval(POLLING) if POLLING
+  POLLING = null
 
 
 init = (windowImpl = window) ->
   WINDOW = windowImpl
-  return if polling
+  return if POLLING # if set that indicates we've been called twice
   api.channel.on 'notifications.fetch.*', loaded
   pollForUpdate()
-  polling = WINDOW.setInterval(pollForUpdate, POLL_INTERVAL)
+  POLLING = WINDOW.setInterval(pollForUpdate, POLL_INTERVAL)
 
 
 module.exports = {

--- a/src/navigation/notifications-model.coffee
+++ b/src/navigation/notifications-model.coffee
@@ -34,7 +34,8 @@ getActive = ->
 
 
 loaded = (resp) ->
-  notifications = resp.data
+  resp.stopErrorDisplay = true
+  notifications = resp.data or []
   observedIds = getObservedNoticeIds()
   newActiveNotices = {}
   currentIds = []

--- a/src/navigation/notifications-model.coffee
+++ b/src/navigation/notifications-model.coffee
@@ -63,7 +63,7 @@ destroy = (windowImpl = window) ->
 
 init = (windowImpl = window) ->
   WINDOW = windowImpl
-  return if POLLING # if set that indicates we've been called twice
+  WINDOW.clearInterval(POLLING) if POLLING
   api.channel.on 'notifications.fetch.*', loaded
   pollForUpdate()
   POLLING = WINDOW.setInterval(pollForUpdate, POLL_INTERVAL)

--- a/src/navigation/notifications-model.coffee
+++ b/src/navigation/notifications-model.coffee
@@ -1,0 +1,76 @@
+_ = require 'underscore'
+EventEmitter2 = require 'eventemitter2'
+api = require '../api'
+
+POLL_INTERVAL = 5 * 60 * 1000 # 5 minutes
+STORAGE_KEY   = 'ox-cc-notifications'
+WINDOW = window
+
+pollForUpdate = ->
+  api.channel.emit('notifications.send.fetch') unless window.document.hidden is true
+
+channel = new EventEmitter2
+
+polling = null
+
+activeNotifications = {}
+
+getObservedNoticeIds = ->
+  JSON.parse(WINDOW.localStorage.getItem(STORAGE_KEY) or '[]')
+
+setObservedNoticeIds = (newIds) ->
+  WINDOW.localStorage.setItem(STORAGE_KEY, JSON.stringify(newIds) )
+
+acknowledge = (notice_id) ->
+  setObservedNoticeIds(
+    getObservedNoticeIds().concat(notice_id)
+  )
+  delete activeNotifications[notice_id]
+  channel.emit('change')
+
+
+getActive = ->
+  _.values activeNotifications
+
+
+loaded = (resp) ->
+  notifications = resp.data
+  observedIds = getObservedNoticeIds()
+  newActiveNotices = {}
+  currentIds = []
+  for notice in notifications
+    currentIds.push(notice.id)
+    continue unless observedIds.indexOf(notice.id) is -1
+    newActiveNotices[notice.id] = notice
+
+  activeNotifications = newActiveNotices
+  channel.emit('change')
+
+  # Prune the list of observed notice ids so it doesn't continue to fill up with old notices
+  outdatedIds = _.difference(observedIds, _.without(currentIds, _.keys(newActiveNotices)...))
+  unless _.isEmpty(outdatedIds)
+    setObservedNoticeIds( _.without(observedIds, outdatedIds...) )
+
+
+destroy = (windowImpl = window) ->
+  WINDOW = windowImpl
+  activeNotifications = {}
+  WINDOW.clearInterval(polling) if polling
+
+
+init = (windowImpl = window) ->
+  WINDOW = windowImpl
+  return if polling
+  api.channel.on 'notifications.fetch.*', loaded
+  pollForUpdate()
+  polling = WINDOW.setInterval(pollForUpdate, POLL_INTERVAL)
+
+
+module.exports = {
+  init,
+  destroy,
+  getActive,
+  acknowledge,
+  channel,
+  loaded
+}

--- a/test/navigation/notifications-model.spec.coffee
+++ b/test/navigation/notifications-model.spec.coffee
@@ -1,0 +1,44 @@
+Notifications = require 'navigation/notifications-model'
+
+TEST_NOTICES = require '../../api/notifications/GET'
+
+describe 'Notifications Model', ->
+
+  beforeEach ->
+    @windowImpl =
+      setInterval: sinon.spy()
+      localStorage:
+        getItem: sinon.stub().returns('[]')
+        setItem: sinon.stub()
+      document:
+        hidden: false
+    Notifications.init(@windowImpl)
+    Notifications.loaded(data: TEST_NOTICES)
+
+  afterEach ->
+    Notifications.destroy(@windowImpl)
+
+  it 'polls for updates when started', ->
+    expect(@windowImpl.setInterval).to.have.been.called
+
+  it 'remembers notices when they are dismissed', ->
+    expect(Notifications.getActive()).to.deep.equal(TEST_NOTICES)
+    Notifications.acknowledge(TEST_NOTICES[0].id)
+    expect(@windowImpl.localStorage.setItem).to.have.been.calledWith('ox-cc-notifications', '["1"]')
+
+  it 'does not list items that are ignored', ->
+    @windowImpl.localStorage.getItem.returns('["2"]')
+    Notifications.loaded(data: TEST_NOTICES)
+    expect(Notifications.getActive()).to.deep.equal([ TEST_NOTICES[0] ])
+
+  it 'removes outdated ids from localstorage', (done) ->
+    # mock that we've observed the current notices
+    @windowImpl.localStorage.getItem.returns('["1", "2"]')
+    expect(@windowImpl.localStorage.setItem).not.to.have.been.called
+
+    # load a new set of messages that do not include the previous ones
+    Notifications.loaded(data: [{id: '3', message: 'message three'}])
+
+    # 1 and 2 are removed
+    expect(@windowImpl.localStorage.setItem).to.have.been.calledWith('ox-cc-notifications', '[]')
+    done()

--- a/test/navigation/notifications-model.spec.coffee
+++ b/test/navigation/notifications-model.spec.coffee
@@ -12,6 +12,7 @@ describe 'Notifications Model', ->
         setItem: sinon.stub()
       document:
         hidden: false
+      clearInterval: sinon.spy()
     Notifications.init(@windowImpl)
     Notifications.loaded(data: TEST_NOTICES)
 


### PR DESCRIPTION
Pretty much the exact same thing we're doing in Tutor https://github.com/openstax/tutor-js/pull/1008

Unfortunately, It doesn't share any code with that implementation.  I tried a few things but the stores were just too different for it to make much sense.

Also since they display from the same spot as Tutor we'll have to be careful on how we word things.  For instance the below screenshot is displaying a notification I'd setup earlier to test the Tutor notices.

![screen shot 2016-03-21 at 5 19 17 pm](https://cloud.githubusercontent.com/assets/79566/13936145/a4381760-ef89-11e5-876c-a3844fb7dc94.png)
