### PR TITLE
Redo login or signup page wording and styles

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#d-20160411.a",
+    "openstax-react-components": "openstax/react-components#4c7b65096ce1787182045fd2e42ef78cb9be3fd9",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#4c7b65096ce1787182045fd2e42ef78cb9be3fd9",
+    "openstax-react-components": "openstax/react-components#d-20160414.a",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/resources/styles/components/course/enrollment-code.less
+++ b/resources/styles/components/course/enrollment-code.less
@@ -1,0 +1,7 @@
+.enrollment-code {
+  .btn.enroll {
+    background-color: @openstax-secondary-light;
+    color: white;
+    font-weight: lighter;
+  }
+}

--- a/resources/styles/components/course/index.less
+++ b/resources/styles/components/course/index.less
@@ -1,3 +1,4 @@
 @import './item';
 @import './student_id';
 @import './registration';
+@import './enrollment-code';

--- a/resources/styles/components/course/registration.less
+++ b/resources/styles/components/course/registration.less
@@ -1,30 +1,62 @@
+@import '~openstax-react-components/resources/styles/mixins/flexbox';
+
 .enroll-or-login {
+  min-height: 500px;
+  .flex-display();
+  .flex-direction(column);
+  .align-items(center);
 
-  display: flex;
-
-  > div {
-    flex: 1;
-    padding: 0 10px;
+  .title {
+    margin-top: 5rem;
+    margin-bottom: 3rem;
   }
 
-  h3 { font-size: 2.4rem; }
+  .login-gateway {
+    .flex-display();
+    .align-items(center);
+    .justify-content(center);
+    font-size: 2.5rem;
+    margin-bottom: 3rem;
 
-  .login {
-    p {
-      font-size: 1.8rem;
-      text-align: center;
+    &.is-open {
+      .message{ text-align: center; }
+      a { display: inline-block; }
     }
 
-  }
-
-  .new-registration {
-    hr { display: none; }
-    border-left: 1px solid @openstax-neutral-light;
-    .code-wrapper {
-      margin-left: 10%;
-      width: 80%;
+    &.is-closed {
+        cursor: pointer;
     }
 
+    &.login {
+      width: 400px;
+      height: 140px;
+      &.is-closed {
+        background-color: @openstax-neutral-light;
+        border: 1px solid @openstax-neutral-darker;
+      }
+    }
+
+    &.sign-up {
+      font-size: 2rem;
+      margin-top: 1rem;
+      display: inline;
+      &.is-closed {
+        color: @link-color;
+      }
+      &.is-open {
+        display: block;
+      }
+    }
   }
+
+  .enroll {
+    text-align: center;
+  }
+
+  h2 {
+    font-size: 2.6rem;
+  }
+  h3 { font-size: 2rem; }
+
 
 }

--- a/src/course/enroll-or-login.cjsx
+++ b/src/course/enroll-or-login.cjsx
@@ -6,13 +6,21 @@ LoginGateway = require '../user/login-gateway'
 
 EnrollOrLogin = React.createClass
 
-  propTypes:
-    collectionUUID: React.PropTypes.string.isRequired
-
   render: ->
     <div className="enroll-or-login">
-      <LoginGateway title="Already entered an enrollment code?" />
-      <NewCourseRegistration title='First time here?' {...@props} />
+      <h2 className="title">I already have an account.</h2>
+      <LoginGateway className='login'>Log in</LoginGateway>
+      <div className="enroll">
+        <h3>
+          I’m new to Concept
+          Coach. <LoginGateway className="sign-up">
+            Sign up with enrollment code
+          </LoginGateway>
+        </h3>
+        <p className="hint">
+          If you don’t have an enrollment code, contact your instructor.
+        </p>
+      </div>
     </div>
 
 module.exports = EnrollOrLogin

--- a/src/course/enrollment-code-input.cjsx
+++ b/src/course/enrollment-code-input.cjsx
@@ -8,7 +8,7 @@ Course = require './model'
 {AsyncButton} = require 'openstax-react-components'
 User = require '../user/model'
 
-InviteCodeInput = React.createClass
+EnrollmentCodeInput = React.createClass
 
   propTypes:
     title: React.PropTypes.string.isRequired
@@ -32,6 +32,7 @@ InviteCodeInput = React.createClass
   render: ->
     button =
       <AsyncButton
+        className='enroll'
         isWaiting={!!@props.course.isBusy}
         waitingText={'Registering…'}
         onClick={@startRegistration}
@@ -39,7 +40,7 @@ InviteCodeInput = React.createClass
         Enroll
       </AsyncButton>
 
-    <div className="form-group">
+    <div className="enrollment-code form-group">
       {@renderCurrentCourses() if @props.currentCourses?.length}
       <h3 className="text-center">{@props.title}</h3>
       <hr/>
@@ -52,4 +53,4 @@ InviteCodeInput = React.createClass
       </div>
     </div>
 
-module.exports = InviteCodeInput
+module.exports = EnrollmentCodeInput

--- a/src/course/modify-registration.cjsx
+++ b/src/course/modify-registration.cjsx
@@ -1,7 +1,7 @@
 React = require 'react'
 _ = require 'underscore'
 
-InviteCodeInput = require './invite-code-input'
+EnrollmentCodeInput = require './enrollment-code-input'
 RequestStudentId = require './request-student-id'
 
 ConfirmJoin = require './confirm-join'
@@ -45,7 +45,7 @@ ModifyCourseRegistration = React.createClass
     {course, original} = @state
 
     if course.isIncomplete()
-      <InviteCodeInput
+      <EnrollmentCodeInput
         course={course}
         title={"Leave #{original.description()} for new course/period"} />
     else if course.isPending()

--- a/src/course/new-registration.cjsx
+++ b/src/course/new-registration.cjsx
@@ -5,7 +5,7 @@ Course = require './model'
 User = require '../user/model'
 ENTER = 'Enter'
 
-InviteCodeInput = require './invite-code-input'
+EnrollmentCodeInput = require './enrollment-code-input'
 ConfirmJoin = require './confirm-join'
 Navigation = require '../navigation/model'
 User = require '../user/model'
@@ -61,7 +61,7 @@ NewCourseRegistration = React.createClass
       @renderValidated()
     else if course.isIncomplete()
       title = if @isTeacher() then '' else @props.title
-      <InviteCodeInput course={course} currentCourses={User.registeredCourses()} title={title} />
+      <EnrollmentCodeInput course={course} currentCourses={User.registeredCourses()} title={title} />
     else if course.isPending()
       <ConfirmJoin
         title={"Would you like to join #{@state.course.description()}?"}

--- a/src/user/login-gateway.cjsx
+++ b/src/user/login-gateway.cjsx
@@ -9,17 +9,11 @@ SECOND = 1000
 LoginGateway = React.createClass
 
   propTypes:
-    wrapperElement: React.PropTypes.element
-    title: React.PropTypes.string
-
     window: React.PropTypes.shape(
       open: React.PropTypes.func
     )
 
   getDefaultProps: ->
-    wrapperElement: React.createElement('p')
-
-    title: 'You need to login or signup in order to use ConceptCoach™'
     window: window
 
   getInitialState: ->

--- a/src/user/login-gateway.cjsx
+++ b/src/user/login-gateway.cjsx
@@ -2,18 +2,23 @@ React = require 'react'
 _ = require 'underscore'
 User  = require './model'
 api   = require '../api'
+classnames = require 'classnames'
 
 SECOND = 1000
 
 LoginGateway = React.createClass
 
   propTypes:
+    wrapperElement: React.PropTypes.element
     title: React.PropTypes.string
+
     window: React.PropTypes.shape(
       open: React.PropTypes.func
     )
 
   getDefaultProps: ->
+    wrapperElement: React.createElement('p')
+
     title: 'You need to login or signup in order to use ConceptCoach™'
     window: window
 
@@ -55,28 +60,23 @@ LoginGateway = React.createClass
     else
       _.delay( @windowClosedCheck, SECOND)
 
-  renderWaiting: ->
-    <p>
-      Please log in using your OpenStax account in the window. {@loginLink('Click to reopen window.')}
-    </p>
-
   urlForLogin: ->
     User.endpoints.login + '?parent=' + encodeURIComponent(window.location.href)
 
-  loginLink: (msg) ->
-    <a data-bypass className='login' onClick={@openLogin} href={@urlForLogin()}>
-      {msg}
-    </a>
-
-  renderLogin: ->
-    <p>
-      {@loginLink('click to begin login.')}
-    </p>
+  renderOpenMessage: ->
+    <span className="message">
+      Please log in using your OpenStax account in the window. <a data-bypass
+        onClick={@openLogin} href={@urlForLogin()}
+      >Click to reopen window.</a>
+    </span>
 
   render: ->
-    <div className='login'>
-      <h3>{@props.title}</h3>
-      {if @state.loginWindow then @renderWaiting() else @renderLogin()}
+    classes = classnames('login-gateway', @props.className,
+      'is-open': @state.loginWindow
+      'is-closed': not @state.loginWindow
+    )
+    <div className={classes} onClick={@openLogin}>
+      {if @state.loginWindow then @renderOpenMessage() else @props.children}
     </div>
 
 module.exports = LoginGateway

--- a/src/user/login-gateway.cjsx
+++ b/src/user/login-gateway.cjsx
@@ -69,7 +69,7 @@ LoginGateway = React.createClass
       'is-open': @state.loginWindow
       'is-closed': not @state.loginWindow
     )
-    <div className={classes} onClick={@openLogin}>
+    <div role="link" className={classes} onClick={@openLogin}>
       {if @state.loginWindow then @renderOpenMessage() else @props.children}
     </div>
 

--- a/test/course/enroll-or-login.spec.coffee
+++ b/test/course/enroll-or-login.spec.coffee
@@ -1,0 +1,25 @@
+{Testing, expect, sinon, _, ReactTestUtils} = require 'openstax-react-components/test/helpers'
+
+Course = require 'course/model'
+NewCourseRegistration = require 'course/new-registration'
+User = require 'user/model'
+EnrollOrLogin = require 'course/enroll-or-login'
+
+
+describe 'EnrollOrLogin Component', ->
+
+  it 'renders actions', ->
+    Testing.renderComponent( EnrollOrLogin, props: {} ).then ({dom}) ->
+      expect(dom.textContent).to.include 'Log in'
+      expect(dom.textContent).to.include 'Sign up with enrollment code'
+
+
+  it 'updates text when log in is clicked', ->
+    Testing.renderComponent( EnrollOrLogin, props: {} ).then ({dom}) ->
+      login = dom.querySelector('.login-gateway.login')
+      Testing.actions.click(login)
+      expect(
+        login.classList.contains('is-open')
+      ).to.be.true
+      expect(login.textContent).to
+        .equal('Please log in using your OpenStax account in the window. Click to reopen window.')

--- a/test/course/enrollment-code-input.spec.coffee
+++ b/test/course/enrollment-code-input.spec.coffee
@@ -1,10 +1,10 @@
 {Testing, expect, sinon, _, ReactTestUtils} = require 'openstax-react-components/test/helpers'
 
-InviteCodeInput = require 'course/invite-code-input'
+EnrollmentCodeInput = require 'course/enrollment-code-input'
 Course = require 'course/model'
 STATUS = require '../../auth/status/GET'
 
-describe 'InviteCodeInput Component', ->
+describe 'EnrollmentCodeInput Component', ->
 
   beforeEach ->
     @props =
@@ -14,20 +14,20 @@ describe 'InviteCodeInput Component', ->
 
   it 'lists current courses', ->
     @props.optionalStudentId = true
-    Testing.renderComponent( InviteCodeInput, props: @props ).then ({dom}) ->
+    Testing.renderComponent( EnrollmentCodeInput, props: @props ).then ({dom}) ->
       courses = _.pluck(dom.querySelectorAll('.list-group-item'), 'textContent')
       expect(courses).to.deep.equal(['Biology I 1st'])
 
   it 'model registers when submit is clicked', ->
     sinon.stub(@props.course, 'register')
-    Testing.renderComponent( InviteCodeInput, props: @props ).then ({dom}) =>
+    Testing.renderComponent( EnrollmentCodeInput, props: @props ).then ({dom}) =>
       dom.querySelector('input').value = 'test'
       Testing.actions.click(dom.querySelector('.btn-default'))
       expect(@props.course.register).to.have.been.calledWith('test')
 
   it 'model registers when enter is pressed in input', ->
     sinon.stub(@props.course, 'register')
-    Testing.renderComponent( InviteCodeInput, props: @props ).then ({dom}) =>
+    Testing.renderComponent( EnrollmentCodeInput, props: @props ).then ({dom}) =>
       input = dom.querySelector('input')
       input.value = 'test'
       ReactTestUtils.Simulate.keyPress(input, {key: "Enter"})

--- a/test/course/new-registration.spec.coffee
+++ b/test/course/new-registration.spec.coffee
@@ -3,7 +3,7 @@
 Course = require 'course/model'
 NewCourseRegistration = require 'course/new-registration'
 User = require 'user/model'
-InviteCodeInput = require 'course/invite-code-input'
+EnrollmentCodeInput = require 'course/enrollment-code-input'
 ConfirmJoin = require 'course/confirm-join'
 
 describe 'NewCourseRegistration Component', ->
@@ -23,15 +23,15 @@ describe 'NewCourseRegistration Component', ->
       Testing.renderComponent( NewCourseRegistration, props: @props ).then ({dom}) ->
         expect(dom.querySelector('.teacher-message')).not.to.be.null
 
-  it 'renders invite code input if course is incomplete', ->
+  it 'renders enrollment code input if course is incomplete', ->
     sinon.stub(@props.course, 'isIncomplete').returns(true)
     Testing.renderComponent( NewCourseRegistration, props: @props ).then ({element}) ->
       expect(ReactTestUtils.scryRenderedComponentsWithType(element, ConfirmJoin)).to.be.empty
-      expect(ReactTestUtils.scryRenderedComponentsWithType(element, InviteCodeInput)).not.to.be.empty
+      expect(ReactTestUtils.scryRenderedComponentsWithType(element, EnrollmentCodeInput)).not.to.be.empty
 
   it 'renders confirmation if course is pending', ->
     sinon.stub(@props.course, 'isIncomplete').returns(false)
     sinon.stub(@props.course, 'isPending').returns(true)
     Testing.renderComponent( NewCourseRegistration, props: @props ).then ({element}) ->
       expect(ReactTestUtils.scryRenderedComponentsWithType(element, ConfirmJoin)).not.to.be.empty
-      expect(ReactTestUtils.scryRenderedComponentsWithType(element, InviteCodeInput)).to.be.empty
+      expect(ReactTestUtils.scryRenderedComponentsWithType(element, EnrollmentCodeInput)).to.be.empty

--- a/test/course/registration.spec.coffee
+++ b/test/course/registration.spec.coffee
@@ -4,6 +4,7 @@ Course = require 'course/model'
 STATUS = require '../../auth/status/GET'
 User = require 'user/model'
 Registration = require 'course/registration'
+EnrollOrLogin = require 'course/enroll-or-login'
 NewCourseRegistration = require 'course/new-registration'
 ModifyCourseRegistration = require 'course/modify-registration'
 
@@ -12,9 +13,16 @@ describe 'Registration Component', ->
   beforeEach ->
     @props =
       collectionUUID: 'test-collection-uuid'
+    @course = new Course(STATUS.courses[0])
+    @sandbox = sinon.sandbox.create()
+    @sandbox.stub(User, 'getCourse').returns(@course)
+    @sandbox.stub(User, 'isLoggedIn').returns(true)
 
+  afterEach ->
+    @sandbox.restore()
 
   it 'renders new if course is new', ->
+    sinon.stub(@course, 'isRegistered').returns(false)
     Testing.renderComponent( Registration, props: @props ).then ({element}) ->
       expect(
         ReactTestUtils.scryRenderedComponentsWithType(element, NewCourseRegistration)
@@ -22,9 +30,17 @@ describe 'Registration Component', ->
 
 
   it 'renders modify if course is already registered', ->
-    course = new Course(STATUS.courses[0])
-    sinon.stub(User, 'getCourse').returns(course)
     Testing.renderComponent( Registration, props: @props ).then ({element}) ->
       expect(
         ReactTestUtils.scryRenderedComponentsWithType(element, ModifyCourseRegistration)
+      ).not.to.be.empty
+
+  it 'asks to enroll or login if user doesnt have course and isnt logged in', ->
+    User.getCourse.restore()
+    User.isLoggedIn.restore()
+    @sandbox.stub(User, 'isLoggedIn').returns(false)
+    @sandbox.stub(User, 'getCourse').returns(null)
+    Testing.renderComponent( Registration, props: @props ).then ({element}) ->
+      expect(
+        ReactTestUtils.scryRenderedComponentsWithType(element, EnrollOrLogin)
       ).not.to.be.empty

--- a/test/user/login-gateway.spec.coffee
+++ b/test/user/login-gateway.spec.coffee
@@ -7,18 +7,19 @@ LoginGateway = require 'user/login-gateway'
 describe 'User login gateway component', ->
   beforeEach ->
     @props =
-      title: 'My Login Screen'
+      children: 'My Login Screen'
       window:
         open: sinon.stub().returns({})
     User.endpoints.login = '/test-login'
 
-  it 'sets title', ->
-    Testing.renderComponent( LoginGateway, props: @props ).then ({dom}) =>
-      expect(dom.querySelector('h3').textContent).to.equal(@props.title)
+  it 'renders children', ->
+    Testing.renderComponent( LoginGateway, props: @props, [@title])
+      .then ({dom}) =>
+        expect(dom.textContent).to.equal(@props.children)
 
   it 'opens a propup window when clicked', ->
     Testing.renderComponent( LoginGateway, props: @props ).then ({dom, element}) =>
-      Testing.actions.click(dom.querySelector('a.login'))
+      Testing.actions.click(dom)
       expect(@props.window.open).to.have.been.calledWith(
         sinon.match(/test-login\?parent=http%3A%2F%2Flocalhost%3A\d+%2Fcontext.html/), 'oxlogin',
         sinon.match(/toolbar=no,location=yes,directories=no,status=no,menubar=no,scrollbars=yes,resizable=yes,copyhistory=no,width=\d+,height=\d+,top=\d+,left=\d+/)


### PR DESCRIPTION
https://github.com/openstax/react-components/pull/57  needs to be merged first - CC fails to build it's styles without it.

This is somewhat confusing to me because both links really do the same thing.  They both sign the user in and then see if they're enrolled.  If they are enrolled, they start working, otherwise they get the enrollment box.

**Note**: that this doesn't completely match the mockup.  The mockup has a light grey background with huge white "Login" button.  In order to match the other CC panel card styles this keeps the background white and makes the button be light grey.

![screen shot 2016-04-13 at 3 23 07 pm](https://cloud.githubusercontent.com/assets/79566/14508233/179f858a-018c-11e6-94b5-b674e3f2efc4.png)
