### PR TITLE
Fix delayed step appearance

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#6844639",
+    "openstax-react-components": "openstax/react-components#ef1c095f6e6e6d46133242b610833e6009d0f805",
     "underscore": "1.8.3"
   },
   "devDependencies": {

--- a/src/exercise/index.cjsx
+++ b/src/exercise/index.cjsx
@@ -15,7 +15,7 @@ ExerciseBase = React.createClass
 
   getStepState: (props) ->
     props ?= @props
-    {item} = @props
+    {item} = props
 
     step: _.last(item)
     parts: item


### PR DESCRIPTION
A rather strange bug, in @kjdav's words:

After answering the free response in Concept Coach, something must be clicked to show the free response answer on the multiple choice step. Clicking on an answer selects the answer, but doesn't activate the submit button. Clicking on the breadcrumb, an answer, or window refresh will show the free response answer and clicking on a multiple choice answer at this point works.

Turned out we were setting the exercise state from the current props, rather than the next ones.  Therefore anything that triggered a prop set (like clicking controls), would advance the state to be correct.

Also updates react-components to pull in MPQ scroll fixes
