### PR TITLE
fix double mc with updating react-components

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "jquery": "2.1.4",
     "keymaster": "1.6.2",
     "lodash": "3.10.1",
-    "openstax-react-components": "openstax/react-components#ef1c095f6e6e6d46133242b610833e6009d0f805",
+    "openstax-react-components": "openstax/react-components#d-20160711.a",
     "underscore": "1.8.3"
   },
   "devDependencies": {


### PR DESCRIPTION
also need to dist this afterwards and make a PR on cnx, should work, reproduced the bug locally only when embedded in webview, and then properly updating with a [disted version of this](https://github.com/openstax/concept-coach/tree/dist-local/test-double-mced) fixes the [double MC problem](https://www.pivotaltracker.com/story/show/126066679)
