### PR TITLE
Confirm join screen title should be full-width

### DIFF
--- a/resources/styles/components/course/confirm-join.less
+++ b/resources/styles/components/course/confirm-join.less
@@ -40,7 +40,6 @@
   .title {
     font-size: 24px;
     border-bottom: 2px solid grey;
-    display: inline-block;
     padding: 20px 50px; // extend border past sides of text
     margin: 20px auto;
     border-bottom: 2px solid @openstax-neutral-light;


### PR DESCRIPTION
Otherwise the next line may wrap beside when course name is short.  No idea why I used `inline-block` previously 😞 

Fixes:
![screen shot 2016-07-14 at 2 29 50 pm](https://cloud.githubusercontent.com/assets/79566/16852853/709a9540-49cf-11e6-95cf-cb714a971470.png)
