### PR TITLE
Add in project property for exercises

### DIFF
--- a/src/exercise/index.cjsx
+++ b/src/exercise/index.cjsx
@@ -40,6 +40,7 @@ ExerciseBase = React.createClass
     return null if _.isEmpty(step)
 
     exerciseProps =
+      project: 'concept-coach'
       taskId: step.task_id
       parts: [step]
       getCurrentPanel: getCurrentPanel


### PR DESCRIPTION
Pivotal ticket: https://www.pivotaltracker.com/story/show/126174111

We weren't adding in the project property, and that was messing up the tooltips.

![screen shot 2016-07-14 at 9 29 18 am](https://cloud.githubusercontent.com/assets/6434717/16878999/a1e26c92-4a7c-11e6-9ced-19aaa9211d8a.png)
